### PR TITLE
ci: replace existing artifacts when re-running a release

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -30,6 +30,11 @@ archives:
       {{- else }}{{ .Arch }}{{ end }}
       {{- if .Arm }}v{{ .Arm }}{{ end }}
 
+release:
+  # Allow re-running a failed release for the same tag without hitting
+  # "422 already_exists" on assets uploaded by the earlier attempt.
+  replace_existing_artifacts: true
+
 changelog:
   sort: asc
   filters:


### PR DESCRIPTION
## Problem

The `v0.5.2` release run failed on an expired Homebrew tap token — but only *after* it had already created the GitHub release and uploaded all 10 assets.

Re-running the job with a refreshed token then failed for a different reason: goreleaser rebuilds from scratch and tried to re-upload assets that were already present.

```
upload failed  error=POST https://uploads.github.com/repos/jsando/fatimg/releases/359612488/assets?name=fatimg_Linux_i386.tar.gz:
  422 Validation Failed [{Resource:ReleaseAsset Field:name Code:already_exists Message:}]
⨯ release failed: scm releases: failed to publish artifacts
```

It aborted at the upload stage, so it never reached the homebrew publish step that had failed in the first place — the re-run could not make progress no matter how many times it ran.

## Fix

Set `release.replace_existing_artifacts: true` so a re-run deletes and replaces conflicting assets instead of erroring, making release runs safely re-runnable.

`v0.5.2` itself was unblocked by deleting its assets manually and re-running; the release and the tap formula are now both correct.

## Follow-ups (not in this PR)

- `brews` is deprecated in GoReleaser v2 in favor of `homebrew_casks`
- `actions/checkout@v4`, `actions/setup-go@v5` and `goreleaser/goreleaser-action@v6` target Node 20 and are being force-run on Node 24