### PR TITLE
fix: build releases with a Go that survives qemu-user emulation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,10 +34,13 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+      # Must be at least the toolchain named in go.mod. This job used to say
+      # '1.24', which made GOTOOLCHAIN fetch exactly the go.mod version and
+      # ship binaries built with a Go that crashes under qemu-user — fatimg#9.
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.24'
+          go-version: '1.25'
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v6
         with:

--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,13 @@ module github.com/jsando/fatimg
 
 go 1.25.0
 
+// Go 1.25.4 carries the fix for golang/go#69255: under qemu-user on an arm64
+// host the amd64 runtime is handed addresses above 47 bits and dies with
+// "taggedPointerPack invalid packing" (older Go: "lfstack.push"). Building
+// with anything earlier ships a binary that cannot run in an emulated amd64
+// container. See fatimg#9. Do not lower this.
+toolchain go1.25.4
+
 require (
 	github.com/diskfs/go-diskfs v1.6.0
 	github.com/dustin/go-humanize v1.0.1


### PR DESCRIPTION
Fixes #9.

## The problem

The released `fatimg_Linux_x86_64` binary crashes immediately when run under qemu-user on an arm64 host — the case that matters for `docker build --platform linux/amd64` on arm64 CI:

```
runtime: taggedPointerPack invalid packing: ptr=0xffff38d30400 tag=0x1 packed=0xffff38d304000001 -> ptr=0xffffffff38d30400 tag=0x1
fatal error: taggedPointerPack
```

qemu-user hands the emulated amd64 process an address above 47 bits, which the amd64 runtime sign-extends into a different pointer. Upstream QEMU ([qemu#2560](https://gitlab.com/qemu-project/qemu/-/issues/2560)) is still open; Go worked around it in [golang/go#69255](https://github.com/golang/go/issues/69255) — landed in Go 1.26, backported to **Go 1.25.4**, never backported to 1.24.

The `GOGC=off` workaround noted in the issue no longer works with current qemu.

## Why our binaries were built with a broken toolchain

`release.yml` pinned the **goreleaser** job to `go-version: '1.24'` while the **test** job used `'1.25'`. With Go 1.24 installed and `go.mod` declaring `go 1.25.0` and no `toolchain` line, `GOTOOLCHAIN=auto` downloads *exactly* go1.25.0 — the last release before the fix. So CI tested on a fixed toolchain (`'1.25'` resolves to the newest patch) and shipped binaries built with a broken one. `go version` on the published v0.5.3 asset confirms it: `go1.25.0`.

## Does bumping the toolchain actually eliminate the crash?

Yes — for every address qemu-user can produce on an arm64 host, which is the entire failure mode in #9.

The Go fix ([commit `2a7f1d47b0`](https://github.com/golang/go/commit/2a7f1d47b0)) is one line in `src/runtime/tagptr_64bit.go`:

```diff
-	defaultAddrBits = 48
+	defaultAddrBits = 48 + 1
```

> We use one extra bit to placate systems which simulate amd64 binaries on an arm64 host. Allocated arm64 addresses could be as high as `1<<48-1`, which would be invalid if we assumed 48-bit sign-extended addresses.

The runtime packs a pointer and a tag into one 64-bit word. On amd64 it assumed 48-bit **sign-extended** addresses, so unpacking sign-extends from bit 47. arm64 user addresses are 48-bit **zero-extended** and run up to `1<<48-1`, so an address with bit 47 set — `0xffff90cee000` — unpacked as `0xffffffff90cee000`, a different pointer, and the runtime aborts rather than corrupt the heap. Keeping 49 address bits covers the whole arm64 user range, so the sign extension can no longer misfire. (The tag field loses a bit, 16 to 15.)

Limits worth recording:

- **It's a workaround, not a cure.** QEMU is still handing the guest addresses no real x86-64 MMU would produce; Go just tolerates them now. qemu#2560 remains open.
- It covers arm64 hosts with a 48-bit user VA, which is every host in practice today. A host with a 52-bit VA (ARMv8.2 LVA, 64K pages) would put us back where we started.
- It fixes this one packing assumption, not amd64-on-arm64 emulation in general.

## The change

- `release.yml` — goreleaser job `go-version: '1.24'` → `'1.25'`, so it matches the test job and resolves to the latest 1.25.x.
- `go.mod` — add `toolchain go1.25.4`, so the floor holds no matter what a developer or CI happens to have installed.

Both carry a comment explaining why, since the failure mode is invisible from the repo.

## Verification

Rig: `fatimg create` under `qemu-x86_64-static` 10.0.11 (Debian trixie) in an arm64 container on Apple Silicon.

Toolchain matrix, 6 MB fixture, 3 runs each:

| Binary | Result |
|---|---|
| Released v0.5.3 (`go1.25.0`) | crashes 3/3 |
| Built with go1.25.0 | crashes 3/3 |
| Built with go1.25.12 | ok 3/3 |
| Built with go1.26.5 | ok 3/3 |

Stress run on a 183 MB fixture (24 files across 3 directories), binary built through the corrected CI path — a `golang:1.25` container cross-compiling to linux/amd64, which resolves to go1.25.12:

| Binary | Runs | Result |
|---|---|---|
| Released v0.5.3 (`go1.25.0`) | 5 | crashes 5/5 |
| Corrected CI path (`go1.25.12`) | 20 | **ok 20/20** |
| Corrected CI path, `GOGC=1` (forced constant GC) | 10 | **ok 10/10** |

The goreleaser job log on this PR confirms the toolchain actually used: `go version go1.25.12 linux/amd64`, `GOTOOLCHAIN='auto'`.

`make check` passes.

Note for anyone reproducing on a Mac: `docker run`/`docker build --platform linux/amd64` uses Rosetta, not qemu-user, when Docker Desktop's Rosetta option is on (default since 4.25.0 on macOS 14.1+) — `/proc/self/maps` shows `/run/rosetta/rosetta`, and the buggy binary runs fine there. Reproducing needs qemu-user explicitly, that option turned off, or the Docker VMM backend, which does not support Rosetta at all. Rancher Desktop defaults `useRosetta` to false, so it uses qemu-user out of the box.
