### PR TITLE
feat: legacy BIOS boot via SYSLINUX (--syslinux), and relicense to GPLv3

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,17 +18,23 @@ jobs:
         uses: actions/setup-go@v5
         with:
           go-version: '1.25'
-      - name: Install FAT validation tools
+      - name: Install validation tools
         # mtools and dosfstools let the tests verify our images against an
-        # independent FAT implementation instead of only against ourselves.
-        run: sudo apt-get update && sudo apt-get install -y mtools dosfstools
+        # independent FAT implementation instead of only against ourselves;
+        # QEMU lets the boot test check that a --bios-boot image actually
+        # boots, which no filesystem check can tell us.
+        run: sudo apt-get update && sudo apt-get install -y mtools dosfstools qemu-system-x86
+      - name: Fetch SYSLINUX
+        # Not vendored: SYSLINUX is GPL-2.0 and fatimg is Apache-2.0.
+        run: make syslinux
       - name: Check formatting
         run: make fmt-check
       - name: Vet
         run: make vet
       - name: Test
-        # -count=1 bypasses the test cache, which does not notice a tool
-        # appearing in a directory that was already on PATH.
-        run: go test -count=1 -v ./...
+        # Run through make so the boot test is pointed at the SYSLINUX release
+        # fetched above. -count=1 bypasses the test cache, which does not
+        # notice a tool appearing in a directory that was already on PATH.
+        run: make test
       - name: Build
         run: make build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,11 +21,11 @@ jobs:
       - name: Install validation tools
         # mtools and dosfstools let the tests verify our images against an
         # independent FAT implementation instead of only against ourselves;
-        # QEMU lets the boot test check that a --bios-boot image actually
+        # QEMU lets the boot test check that a --syslinux image actually
         # boots, which no filesystem check can tell us.
         run: sudo apt-get update && sudo apt-get install -y mtools dosfstools qemu-system-x86
       - name: Fetch SYSLINUX
-        # Not vendored: SYSLINUX is GPL-2.0 and fatimg is Apache-2.0.
+        # Not vendored: we do not redistribute someone else's binaries.
         run: make syslinux
       - name: Check formatting
         run: make fmt-check

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,10 +21,17 @@ jobs:
         uses: actions/setup-go@v5
         with:
           go-version: '1.25'
-      - name: Install FAT validation tools
-        run: sudo apt-get update && sudo apt-get install -y mtools dosfstools
+      # Kept in step with the same steps in ci.yml. This job is the gate on
+      # publishing, so it has to run the same tiers, boot test included.
+      - name: Install validation tools
+        run: sudo apt-get update && sudo apt-get install -y mtools dosfstools qemu-system-x86
+      - name: Fetch SYSLINUX
+        # Not vendored: we do not redistribute someone else's binaries.
+        run: make syslinux
       - name: Test
-        run: go test -count=1 ./...
+        # Run through make so the boot test is pointed at the SYSLINUX release
+        # fetched above.
+        run: make test
 
   goreleaser:
     needs: test

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ dist/
 /fatimg
 test-files/tmp/
 /test-files/
+/.syslinux/

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -51,6 +51,6 @@ brews:
     directory: Formula
     homepage: "https://github.com/jsando/fatimg"
     description: "Go utility for creating and managing FAT32 boot (EFI) partition disk images"
-    license: "MIT"
+    license: "GPL-3.0-or-later"
     test: |
       system "#{bin}/fatimg", "--version"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,7 +17,7 @@ make build         # build with version info
 make test          # all tests; fails early if a required tool is missing
 make unit          # only the tests that need no external tools
 make integration   # round-trip and external validation tests, verbose
-make boot          # boot a --bios-boot image under QEMU, verbose
+make boot          # boot a --syslinux image under QEMU, verbose
 make syslinux      # download the SYSLINUX release the boot test installs
 make check         # what CI runs: gofmt, vet, tests
 make help          # list all targets
@@ -44,7 +44,7 @@ A small command pattern: `main.go` dispatches to one `Runner` per subcommand.
 | `cp` | `copy.go` | Extract to a local directory |
 
 `boot.go` is not a subcommand: it is the SYSLINUX installer behind
-`create --bios-boot`, and runs after the filesystem is closed, on the image as
+`create --syslinux`, and runs after the filesystem is closed, on the image as
 a plain file.
 
 Commands return errors; they must not call `os.Exit`. Tests drive
@@ -121,7 +121,7 @@ Four tiers, all under `go test`:
 3. **External validation** (`external_test.go`) — `mdir`, `mcopy` and
    `fsck.fat` check the image against independent FAT implementations, so a
    self-consistent but non-conforming filesystem cannot pass.
-4. **Boot** (`qemu_test.go`) — build a `--bios-boot` image and run it on an
+4. **Boot** (`qemu_test.go`) — build a `--syslinux` image and run it on an
    emulated PC, checking that SYSLINUX reached the `syslinux.cfg` in the image.
    Nothing below this tier can catch a broken bootloader install: an image with
    no boot code at all passes every other test here, because a boot sector is

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -86,9 +86,14 @@ time, along with a checksum ldlinux.sys verifies against itself at boot.
 - ldlinux.sys is written before the user's files so it lands contiguously.
   It is addressed by an extent list with room for 192 entries, and a fragmented
   one would overflow it; `generateExtents` errors rather than truncating.
-- SYSLINUX is not vendored or embedded. It is GPL-2.0 and fatimg is Apache-2.0,
-  so the files come from `--syslinux-dir` at run time. Do not add a `go:embed`
-  of them without settling that first.
+- SYSLINUX is not vendored or embedded; the files come from `--syslinux-dir` at
+  run time. Do not add a `go:embed` of them — that would put someone else's
+  binaries inside ours, with their version skew and redistribution obligations,
+  and it is what the `--syslinux-dir` search paths exist to avoid.
+- This file is why the project is GPLv3. The patcher is derived from GPL-2.0+
+  syslinux source, and `boot.go` carries the attribution header; keep it, and
+  keep new work here compatible with those terms. See the License section of
+  README.md.
 - A FAT32 with 65524 clusters or fewer reads as FAT16 by the standard rule, and
   SYSLINUX applies it. `installSyslinux` rejects such an image; without that
   check the symptom is a boot that prints the SYSLINUX banner and then cannot

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,16 +14,21 @@ prerequisites and disable the test cache where it would otherwise mislead.
 
 ```bash
 make build         # build with version info
-make test          # all tests; fails early if mtools/dosfstools are missing
+make test          # all tests; fails early if a required tool is missing
 make unit          # only the tests that need no external tools
 make integration   # round-trip and external validation tests, verbose
+make boot          # boot a --bios-boot image under QEMU, verbose
+make syslinux      # download the SYSLINUX release the boot test installs
 make check         # what CI runs: gofmt, vet, tests
 make help          # list all targets
 ```
 
-`make test` requires `mtools` and `dosfstools` (see the README). A missing tool
-is a failure, not a skip, because a skipped validation tier looks exactly like a
-passing one.
+`make test` requires `mtools`, `dosfstools` and `qemu-system-x86_64` (see the
+README). A missing tool is a failure, not a skip, because a skipped validation
+tier looks exactly like a passing one. The boot test also needs a SYSLINUX
+release; `make` downloads one into `.syslinux/` and exports
+`FATIMG_SYSLINUX_DIR`, so run the boot test through make rather than calling
+`go test` directly.
 
 Releases are built by GoReleaser from a pushed tag; `build-with-version.sh`
 predates the Makefile and `make build` supersedes it.
@@ -37,6 +42,10 @@ A small command pattern: `main.go` dispatches to one `Runner` per subcommand.
 | `create` | `create.go` | MBR-partitioned disk with a single FAT32 partition; recursively copies files in |
 | `ls` | `list.go` | Also holds the gzip sniffing and temp-file decompression shared with `cp` |
 | `cp` | `copy.go` | Extract to a local directory |
+
+`boot.go` is not a subcommand: it is the SYSLINUX installer behind
+`create --bios-boot`, and runs after the filesystem is closed, on the image as
+a plain file.
 
 Commands return errors; they must not call `os.Exit`. Tests drive
 `executeSubcommand` in-process, so an exit would take the test binary with it.
@@ -53,6 +62,37 @@ are switched to `flag.ContinueOnError`.
   removing it if anything fails.
 - `copyFile` reads the whole file into memory before writing so that FAT32
   allocates the cluster chain once; see go-diskfs issue #130.
+- go-diskfs writes placeholders into two BPB fields: hidden sectors is always
+  0, and the CHS geometry is 1/1. Both are wrong for a filesystem inside a
+  partition, and SYSLINUX adds hidden sectors to every sector it reads, so
+  `fixBPBGeometry` corrects them (in the primary and the backup boot sector)
+  for every image, bootable or not.
+
+## SYSLINUX installation (`boot.go`)
+
+Four things make a FAT32 image BIOS-bootable, and only the last is real work:
+`mbr.bin` in the first 440 bytes of sector 0; a correct hidden-sector count;
+the SYSLINUX boot sector merged into the partition, keeping the BPB; and
+`ldlinux.sys` patched with the list of disk sectors it occupies. A 512-byte
+boot sector cannot walk a FAT chain, so the sector map is stamped in at install
+time, along with a checksum ldlinux.sys verifies against itself at boot.
+
+- This follows `syslinux_patch()` in syslinux-6.03
+  `libinstaller/syslxmod.c`. The structure offsets are read out of the image
+  rather than hardcoded, because they are a property of the ldlinux.sys build
+  being installed — which is also why the files must come from one release.
+- `mbr.Table.Write` only touches bytes 446 onwards, so writing the bootstrap at
+  offset 0 cannot disturb the partition table.
+- ldlinux.sys is written before the user's files so it lands contiguously.
+  It is addressed by an extent list with room for 192 entries, and a fragmented
+  one would overflow it; `generateExtents` errors rather than truncating.
+- SYSLINUX is not vendored or embedded. It is GPL-2.0 and fatimg is Apache-2.0,
+  so the files come from `--syslinux-dir` at run time. Do not add a `go:embed`
+  of them without settling that first.
+- A FAT32 with 65524 clusters or fewer reads as FAT16 by the standard rule, and
+  SYSLINUX applies it. `installSyslinux` rejects such an image; without that
+  check the symptom is a boot that prints the SYSLINUX banner and then cannot
+  find ldlinux.c32, which is a long way from the cause.
 
 ## go-diskfs is pinned to v1.6.0 — do not upgrade casually
 
@@ -71,16 +111,21 @@ defects are only visible through `fsck.fat`, which is why that tier exists.
 
 ## Testing approach
 
-Three tiers, all under `go test`:
+Four tiers, all under `go test`:
 
-1. **Unit** (`create_test.go`) — `trimFile` across chunk boundaries, path
-   re-rooting.
+1. **Unit** (`create_test.go`, `boot_test.go`) — `trimFile` across chunk
+   boundaries, path re-rooting, and the SYSLINUX patch arithmetic.
 2. **Round-trip** (`roundtrip_test.go`) — create an image from a fixture tree
    and extract it again, asserting byte-identical contents across the option
    matrix. This is the tier that catches a broken `create`/`ls`/`cp`.
 3. **External validation** (`external_test.go`) — `mdir`, `mcopy` and
    `fsck.fat` check the image against independent FAT implementations, so a
    self-consistent but non-conforming filesystem cannot pass.
+4. **Boot** (`qemu_test.go`) — build a `--bios-boot` image and run it on an
+   emulated PC, checking that SYSLINUX reached the `syslinux.cfg` in the image.
+   Nothing below this tier can catch a broken bootloader install: an image with
+   no boot code at all passes every other test here, because a boot sector is
+   not part of the filesystem as far as `fsck.fat` is concerned.
 
 When fixing a bug, confirm the new test fails with the fix reverted. Every
 regression covered here was verified that way.

--- a/LICENSE
+++ b/LICENSE
@@ -1,202 +1,674 @@
+                    GNU GENERAL PUBLIC LICENSE
+                       Version 3, 29 June 2007
 
-                                 Apache License
-                           Version 2.0, January 2004
-                        http://www.apache.org/licenses/
+ Copyright (C) 2007 Free Software Foundation, Inc. <https://fsf.org/>
+ Everyone is permitted to copy and distribute verbatim copies
+ of this license document, but changing it is not allowed.
 
-   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+                            Preamble
 
-   1. Definitions.
+  The GNU General Public License is a free, copyleft license for
+software and other kinds of works.
 
-      "License" shall mean the terms and conditions for use, reproduction,
-      and distribution as defined by Sections 1 through 9 of this document.
+  The licenses for most software and other practical works are designed
+to take away your freedom to share and change the works.  By contrast,
+the GNU General Public License is intended to guarantee your freedom to
+share and change all versions of a program--to make sure it remains free
+software for all its users.  We, the Free Software Foundation, use the
+GNU General Public License for most of our software; it applies also to
+any other work released this way by its authors.  You can apply it to
+your programs, too.
 
-      "Licensor" shall mean the copyright owner or entity authorized by
-      the copyright owner that is granting the License.
+  When we speak of free software, we are referring to freedom, not
+price.  Our General Public Licenses are designed to make sure that you
+have the freedom to distribute copies of free software (and charge for
+them if you wish), that you receive source code or can get it if you
+want it, that you can change the software or use pieces of it in new
+free programs, and that you know you can do these things.
 
-      "Legal Entity" shall mean the union of the acting entity and all
-      other entities that control, are controlled by, or are under common
-      control with that entity. For the purposes of this definition,
-      "control" means (i) the power, direct or indirect, to cause the
-      direction or management of such entity, whether by contract or
-      otherwise, or (ii) ownership of fifty percent (50%) or more of the
-      outstanding shares, or (iii) beneficial ownership of such entity.
+  To protect your rights, we need to prevent others from denying you
+these rights or asking you to surrender the rights.  Therefore, you have
+certain responsibilities if you distribute copies of the software, or if
+you modify it: responsibilities to respect the freedom of others.
 
-      "You" (or "Your") shall mean an individual or Legal Entity
-      exercising permissions granted by this License.
+  For example, if you distribute copies of such a program, whether
+gratis or for a fee, you must pass on to the recipients the same
+freedoms that you received.  You must make sure that they, too, receive
+or can get the source code.  And you must show them these terms so they
+know their rights.
 
-      "Source" form shall mean the preferred form for making modifications,
-      including but not limited to software source code, documentation
-      source, and configuration files.
+  Developers that use the GNU GPL protect your rights with two steps:
+(1) assert copyright on the software, and (2) offer you this License
+giving you legal permission to copy, distribute and/or modify it.
 
-      "Object" form shall mean any form resulting from mechanical
-      transformation or translation of a Source form, including but
-      not limited to compiled object code, generated documentation,
-      and conversions to other media types.
+  For the developers' and authors' protection, the GPL clearly explains
+that there is no warranty for this free software.  For both users' and
+authors' sake, the GPL requires that modified versions be marked as
+changed, so that their problems will not be attributed erroneously to
+authors of previous versions.
 
-      "Work" shall mean the work of authorship, whether in Source or
-      Object form, made available under the License, as indicated by a
-      copyright notice that is included in or attached to the work
-      (an example is provided in the Appendix below).
+  Some devices are designed to deny users access to install or run
+modified versions of the software inside them, although the manufacturer
+can do so.  This is fundamentally incompatible with the aim of
+protecting users' freedom to change the software.  The systematic
+pattern of such abuse occurs in the area of products for individuals to
+use, which is precisely where it is most unacceptable.  Therefore, we
+have designed this version of the GPL to prohibit the practice for those
+products.  If such problems arise substantially in other domains, we
+stand ready to extend this provision to those domains in future versions
+of the GPL, as needed to protect the freedom of users.
 
-      "Derivative Works" shall mean any work, whether in Source or Object
-      form, that is based on (or derived from) the Work and for which the
-      editorial revisions, annotations, elaborations, or other modifications
-      represent, as a whole, an original work of authorship. For the purposes
-      of this License, Derivative Works shall not include works that remain
-      separable from, or merely link (or bind by name) to the interfaces of,
-      the Work and Derivative Works thereof.
+  Finally, every program is threatened constantly by software patents.
+States should not allow patents to restrict development and use of
+software on general-purpose computers, but in those that do, we wish to
+avoid the special danger that patents applied to a free program could
+make it effectively proprietary.  To prevent this, the GPL assures that
+patents cannot be used to render the program non-free.
 
-      "Contribution" shall mean any work of authorship, including
-      the original version of the Work and any modifications or additions
-      to that Work or Derivative Works thereof, that is intentionally
-      submitted to Licensor for inclusion in the Work by the copyright owner
-      or by an individual or Legal Entity authorized to submit on behalf of
-      the copyright owner. For the purposes of this definition, "submitted"
-      means any form of electronic, verbal, or written communication sent
-      to the Licensor or its representatives, including but not limited to
-      communication on electronic mailing lists, source code control systems,
-      and issue tracking systems that are managed by, or on behalf of, the
-      Licensor for the purpose of discussing and improving the Work, but
-      excluding communication that is conspicuously marked or otherwise
-      designated in writing by the copyright owner as "Not a Contribution."
+  The precise terms and conditions for copying, distribution and
+modification follow.
 
-      "Contributor" shall mean Licensor and any individual or Legal Entity
-      on behalf of whom a Contribution has been received by Licensor and
-      subsequently incorporated within the Work.
+                       TERMS AND CONDITIONS
 
-   2. Grant of Copyright License. Subject to the terms and conditions of
-      this License, each Contributor hereby grants to You a perpetual,
-      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
-      copyright license to reproduce, prepare Derivative Works of,
-      publicly display, publicly perform, sublicense, and distribute the
-      Work and such Derivative Works in Source or Object form.
+  0. Definitions.
 
-   3. Grant of Patent License. Subject to the terms and conditions of
-      this License, each Contributor hereby grants to You a perpetual,
-      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
-      (except as stated in this section) patent license to make, have made,
-      use, offer to sell, sell, import, and otherwise transfer the Work,
-      where such license applies only to those patent claims licensable
-      by such Contributor that are necessarily infringed by their
-      Contribution(s) alone or by combination of their Contribution(s)
-      with the Work to which such Contribution(s) was submitted. If You
-      institute patent litigation against any entity (including a
-      cross-claim or counterclaim in a lawsuit) alleging that the Work
-      or a Contribution incorporated within the Work constitutes direct
-      or contributory patent infringement, then any patent licenses
-      granted to You under this License for that Work shall terminate
-      as of the date such litigation is filed.
+  "This License" refers to version 3 of the GNU General Public License.
 
-   4. Redistribution. You may reproduce and distribute copies of the
-      Work or Derivative Works thereof in any medium, with or without
-      modifications, and in Source or Object form, provided that You
-      meet the following conditions:
+  "Copyright" also means copyright-like laws that apply to other kinds of
+works, such as semiconductor masks.
 
-      (a) You must give any other recipients of the Work or
-          Derivative Works a copy of this License; and
+  "The Program" refers to any copyrightable work licensed under this
+License.  Each licensee is addressed as "you".  "Licensees" and
+"recipients" may be individuals or organizations.
 
-      (b) You must cause any modified files to carry prominent notices
-          stating that You changed the files; and
+  To "modify" a work means to copy from or adapt all or part of the work
+in a fashion requiring copyright permission, other than the making of an
+exact copy.  The resulting work is called a "modified version" of the
+earlier work or a work "based on" the earlier work.
 
-      (c) You must retain, in the Source form of any Derivative Works
-          that You distribute, all copyright, patent, trademark, and
-          attribution notices from the Source form of the Work,
-          excluding those notices that do not pertain to any part of
-          the Derivative Works; and
+  A "covered work" means either the unmodified Program or a work based
+on the Program.
 
-      (d) If the Work includes a "NOTICE" text file as part of its
-          distribution, then any Derivative Works that You distribute must
-          include a readable copy of the attribution notices contained
-          within such NOTICE file, excluding those notices that do not
-          pertain to any part of the Derivative Works, in at least one
-          of the following places: within a NOTICE text file distributed
-          as part of the Derivative Works; within the Source form or
-          documentation, if provided along with the Derivative Works; or,
-          within a display generated by the Derivative Works, if and
-          wherever such third-party notices normally appear. The contents
-          of the NOTICE file are for informational purposes only and
-          do not modify the License. You may add Your own attribution
-          notices within Derivative Works that You distribute, alongside
-          or as an addendum to the NOTICE text from the Work, provided
-          that such additional attribution notices cannot be construed
-          as modifying the License.
+  To "propagate" a work means to do anything with it that, without
+permission, would make you directly or secondarily liable for
+infringement under applicable copyright law, except executing it on a
+computer or modifying a private copy.  Propagation includes copying,
+distribution (with or without modification), making available to the
+public, and in some countries other activities as well.
 
-      You may add Your own copyright statement to Your modifications and
-      may provide additional or different license terms and conditions
-      for use, reproduction, or distribution of Your modifications, or
-      for any such Derivative Works as a whole, provided Your use,
-      reproduction, and distribution of the Work otherwise complies with
-      the conditions stated in this License.
+  To "convey" a work means any kind of propagation that enables other
+parties to make or receive copies.  Mere interaction with a user through
+a computer network, with no transfer of a copy, is not conveying.
 
-   5. Submission of Contributions. Unless You explicitly state otherwise,
-      any Contribution intentionally submitted for inclusion in the Work
-      by You to the Licensor shall be under the terms and conditions of
-      this License, without any additional terms or conditions.
-      Notwithstanding the above, nothing herein shall supersede or modify
-      the terms of any separate license agreement you may have executed
-      with Licensor regarding such Contributions.
+  An interactive user interface displays "Appropriate Legal Notices"
+to the extent that it includes a convenient and prominently visible
+feature that (1) displays an appropriate copyright notice, and (2)
+tells the user that there is no warranty for the work (except to the
+extent that warranties are provided), that licensees may convey the
+work under this License, and how to view a copy of this License.  If
+the interface presents a list of user commands or options, such as a
+menu, a prominent item in the list meets this criterion.
 
-   6. Trademarks. This License does not grant permission to use the trade
-      names, trademarks, service marks, or product names of the Licensor,
-      except as required for reasonable and customary use in describing the
-      origin of the Work and reproducing the content of the NOTICE file.
+  1. Source Code.
 
-   7. Disclaimer of Warranty. Unless required by applicable law or
-      agreed to in writing, Licensor provides the Work (and each
-      Contributor provides its Contributions) on an "AS IS" BASIS,
-      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
-      implied, including, without limitation, any warranties or conditions
-      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
-      PARTICULAR PURPOSE. You are solely responsible for determining the
-      appropriateness of using or redistributing the Work and assume any
-      risks associated with Your exercise of permissions under this License.
+  The "source code" for a work means the preferred form of the work
+for making modifications to it.  "Object code" means any non-source
+form of a work.
 
-   8. Limitation of Liability. In no event and under no legal theory,
-      whether in tort (including negligence), contract, or otherwise,
-      unless required by applicable law (such as deliberate and grossly
-      negligent acts) or agreed to in writing, shall any Contributor be
-      liable to You for damages, including any direct, indirect, special,
-      incidental, or consequential damages of any character arising as a
-      result of this License or out of the use or inability to use the
-      Work (including but not limited to damages for loss of goodwill,
-      work stoppage, computer failure or malfunction, or any and all
-      other commercial damages or losses), even if such Contributor
-      has been advised of the possibility of such damages.
+  A "Standard Interface" means an interface that either is an official
+standard defined by a recognized standards body, or, in the case of
+interfaces specified for a particular programming language, one that
+is widely used among developers working in that language.
 
-   9. Accepting Warranty or Additional Liability. While redistributing
-      the Work or Derivative Works thereof, You may choose to offer,
-      and charge a fee for, acceptance of support, warranty, indemnity,
-      or other liability obligations and/or rights consistent with this
-      License. However, in accepting such obligations, You may act only
-      on Your own behalf and on Your sole responsibility, not on behalf
-      of any other Contributor, and only if You agree to indemnify,
-      defend, and hold each Contributor harmless for any liability
-      incurred by, or claims asserted against, such Contributor by reason
-      of your accepting any such warranty or additional liability.
+  The "System Libraries" of an executable work include anything, other
+than the work as a whole, that (a) is included in the normal form of
+packaging a Major Component, but which is not part of that Major
+Component, and (b) serves only to enable use of the work with that
+Major Component, or to implement a Standard Interface for which an
+implementation is available to the public in source code form.  A
+"Major Component", in this context, means a major essential component
+(kernel, window system, and so on) of the specific operating system
+(if any) on which the executable work runs, or a compiler used to
+produce the work, or an object code interpreter used to run it.
 
-   END OF TERMS AND CONDITIONS
+  The "Corresponding Source" for a work in object code form means all
+the source code needed to generate, install, and (for an executable
+work) run the object code and to modify the work, including scripts to
+control those activities.  However, it does not include the work's
+System Libraries, or general-purpose tools or generally available free
+programs which are used unmodified in performing those activities but
+which are not part of the work.  For example, Corresponding Source
+includes interface definition files associated with source files for
+the work, and the source code for shared libraries and dynamically
+linked subprograms that the work is specifically designed to require,
+such as by intimate data communication or control flow between those
+subprograms and other parts of the work.
 
-   APPENDIX: How to apply the Apache License to your work.
+  The Corresponding Source need not include anything that users
+can regenerate automatically from other parts of the Corresponding
+Source.
 
-      To apply the Apache License to your work, attach the following
-      boilerplate notice, with the fields enclosed by brackets "[]"
-      replaced with your own identifying information. (Don't include
-      the brackets!)  The text should be enclosed in the appropriate
-      comment syntax for the file format. We also recommend that a
-      file or class name and description of purpose be included on the
-      same "printed page" as the copyright notice for easier
-      identification within third-party archives.
+  The Corresponding Source for a work in source code form is that
+same work.
 
-   Copyright [yyyy] [name of copyright owner]
+  2. Basic Permissions.
 
-   Licensed under the Apache License, Version 2.0 (the "License");
-   you may not use this file except in compliance with the License.
-   You may obtain a copy of the License at
+  All rights granted under this License are granted for the term of
+copyright on the Program, and are irrevocable provided the stated
+conditions are met.  This License explicitly affirms your unlimited
+permission to run the unmodified Program.  The output from running a
+covered work is covered by this License only if the output, given its
+content, constitutes a covered work.  This License acknowledges your
+rights of fair use or other equivalent, as provided by copyright law.
 
-       http://www.apache.org/licenses/LICENSE-2.0
+  You may make, run and propagate covered works that you do not
+convey, without conditions so long as your license otherwise remains
+in force.  You may convey covered works to others for the sole purpose
+of having them make modifications exclusively for you, or provide you
+with facilities for running those works, provided that you comply with
+the terms of this License in conveying all material for which you do
+not control copyright.  Those thus making or running the covered works
+for you must do so exclusively on your behalf, under your direction
+and control, on terms that prohibit them from making any copies of
+your copyrighted material outside their relationship with you.
 
-   Unless required by applicable law or agreed to in writing, software
-   distributed under the License is distributed on an "AS IS" BASIS,
-   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-   See the License for the specific language governing permissions and
-   limitations under the License.
+  Conveying under any other circumstances is permitted solely under
+the conditions stated below.  Sublicensing is not allowed; section 10
+makes it unnecessary.
+
+  3. Protecting Users' Legal Rights From Anti-Circumvention Law.
+
+  No covered work shall be deemed part of an effective technological
+measure under any applicable law fulfilling obligations under article
+11 of the WIPO copyright treaty adopted on 20 December 1996, or
+similar laws prohibiting or restricting circumvention of such
+measures.
+
+  When you convey a covered work, you waive any legal power to forbid
+circumvention of technological measures to the extent such circumvention
+is effected by exercising rights under this License with respect to
+the covered work, and you disclaim any intention to limit operation or
+modification of the work as a means of enforcing, against the work's
+users, your or third parties' legal rights to forbid circumvention of
+technological measures.
+
+  4. Conveying Verbatim Copies.
+
+  You may convey verbatim copies of the Program's source code as you
+receive it, in any medium, provided that you conspicuously and
+appropriately publish on each copy an appropriate copyright notice;
+keep intact all notices stating that this License and any
+non-permissive terms added in accord with section 7 apply to the code;
+keep intact all notices of the absence of any warranty; and give all
+recipients a copy of this License along with the Program.
+
+  You may charge any price or no price for each copy that you convey,
+and you may offer support or warranty protection for a fee.
+
+  5. Conveying Modified Source Versions.
+
+  You may convey a work based on the Program, or the modifications to
+produce it from the Program, in the form of source code under the
+terms of section 4, provided that you also meet all of these conditions:
+
+    a) The work must carry prominent notices stating that you modified
+    it, and giving a relevant date.
+
+    b) The work must carry prominent notices stating that it is
+    released under this License and any conditions added under section
+    7.  This requirement modifies the requirement in section 4 to
+    "keep intact all notices".
+
+    c) You must license the entire work, as a whole, under this
+    License to anyone who comes into possession of a copy.  This
+    License will therefore apply, along with any applicable section 7
+    additional terms, to the whole of the work, and all its parts,
+    regardless of how they are packaged.  This License gives no
+    permission to license the work in any other way, but it does not
+    invalidate such permission if you have separately received it.
+
+    d) If the work has interactive user interfaces, each must display
+    Appropriate Legal Notices; however, if the Program has interactive
+    interfaces that do not display Appropriate Legal Notices, your
+    work need not make them do so.
+
+  A compilation of a covered work with other separate and independent
+works, which are not by their nature extensions of the covered work,
+and which are not combined with it such as to form a larger program,
+in or on a volume of a storage or distribution medium, is called an
+"aggregate" if the compilation and its resulting copyright are not
+used to limit the access or legal rights of the compilation's users
+beyond what the individual works permit.  Inclusion of a covered work
+in an aggregate does not cause this License to apply to the other
+parts of the aggregate.
+
+  6. Conveying Non-Source Forms.
+
+  You may convey a covered work in object code form under the terms
+of sections 4 and 5, provided that you also convey the
+machine-readable Corresponding Source under the terms of this License,
+in one of these ways:
+
+    a) Convey the object code in, or embodied in, a physical product
+    (including a physical distribution medium), accompanied by the
+    Corresponding Source fixed on a durable physical medium
+    customarily used for software interchange.
+
+    b) Convey the object code in, or embodied in, a physical product
+    (including a physical distribution medium), accompanied by a
+    written offer, valid for at least three years and valid for as
+    long as you offer spare parts or customer support for that product
+    model, to give anyone who possesses the object code either (1) a
+    copy of the Corresponding Source for all the software in the
+    product that is covered by this License, on a durable physical
+    medium customarily used for software interchange, for a price no
+    more than your reasonable cost of physically performing this
+    conveying of source, or (2) access to copy the
+    Corresponding Source from a network server at no charge.
+
+    c) Convey individual copies of the object code with a copy of the
+    written offer to provide the Corresponding Source.  This
+    alternative is allowed only occasionally and noncommercially, and
+    only if you received the object code with such an offer, in accord
+    with subsection 6b.
+
+    d) Convey the object code by offering access from a designated
+    place (gratis or for a charge), and offer equivalent access to the
+    Corresponding Source in the same way through the same place at no
+    further charge.  You need not require recipients to copy the
+    Corresponding Source along with the object code.  If the place to
+    copy the object code is a network server, the Corresponding Source
+    may be on a different server (operated by you or a third party)
+    that supports equivalent copying facilities, provided you maintain
+    clear directions next to the object code saying where to find the
+    Corresponding Source.  Regardless of what server hosts the
+    Corresponding Source, you remain obligated to ensure that it is
+    available for as long as needed to satisfy these requirements.
+
+    e) Convey the object code using peer-to-peer transmission, provided
+    you inform other peers where the object code and Corresponding
+    Source of the work are being offered to the general public at no
+    charge under subsection 6d.
+
+  A separable portion of the object code, whose source code is excluded
+from the Corresponding Source as a System Library, need not be
+included in conveying the object code work.
+
+  A "User Product" is either (1) a "consumer product", which means any
+tangible personal property which is normally used for personal, family,
+or household purposes, or (2) anything designed or sold for incorporation
+into a dwelling.  In determining whether a product is a consumer product,
+doubtful cases shall be resolved in favor of coverage.  For a particular
+product received by a particular user, "normally used" refers to a
+typical or common use of that class of product, regardless of the status
+of the particular user or of the way in which the particular user
+actually uses, or expects or is expected to use, the product.  A product
+is a consumer product regardless of whether the product has substantial
+commercial, industrial or non-consumer uses, unless such uses represent
+the only significant mode of use of the product.
+
+  "Installation Information" for a User Product means any methods,
+procedures, authorization keys, or other information required to install
+and execute modified versions of a covered work in that User Product from
+a modified version of its Corresponding Source.  The information must
+suffice to ensure that the continued functioning of the modified object
+code is in no case prevented or interfered with solely because
+modification has been made.
+
+  If you convey an object code work under this section in, or with, or
+specifically for use in, a User Product, and the conveying occurs as
+part of a transaction in which the right of possession and use of the
+User Product is transferred to the recipient in perpetuity or for a
+fixed term (regardless of how the transaction is characterized), the
+Corresponding Source conveyed under this section must be accompanied
+by the Installation Information.  But this requirement does not apply
+if neither you nor any third party retains the ability to install
+modified object code on the User Product (for example, the work has
+been installed in ROM).
+
+  The requirement to provide Installation Information does not include a
+requirement to continue to provide support service, warranty, or updates
+for a work that has been modified or installed by the recipient, or for
+the User Product in which it has been modified or installed.  Access to a
+network may be denied when the modification itself materially and
+adversely affects the operation of the network or violates the rules and
+protocols for communication across the network.
+
+  Corresponding Source conveyed, and Installation Information provided,
+in accord with this section must be in a format that is publicly
+documented (and with an implementation available to the public in
+source code form), and must require no special password or key for
+unpacking, reading or copying.
+
+  7. Additional Terms.
+
+  "Additional permissions" are terms that supplement the terms of this
+License by making exceptions from one or more of its conditions.
+Additional permissions that are applicable to the entire Program shall
+be treated as though they were included in this License, to the extent
+that they are valid under applicable law.  If additional permissions
+apply only to part of the Program, that part may be used separately
+under those permissions, but the entire Program remains governed by
+this License without regard to the additional permissions.
+
+  When you convey a copy of a covered work, you may at your option
+remove any additional permissions from that copy, or from any part of
+it.  (Additional permissions may be written to require their own
+removal in certain cases when you modify the work.)  You may place
+additional permissions on material, added by you to a covered work,
+for which you have or can give appropriate copyright permission.
+
+  Notwithstanding any other provision of this License, for material you
+add to a covered work, you may (if authorized by the copyright holders of
+that material) supplement the terms of this License with terms:
+
+    a) Disclaiming warranty or limiting liability differently from the
+    terms of sections 15 and 16 of this License; or
+
+    b) Requiring preservation of specified reasonable legal notices or
+    author attributions in that material or in the Appropriate Legal
+    Notices displayed by works containing it; or
+
+    c) Prohibiting misrepresentation of the origin of that material, or
+    requiring that modified versions of such material be marked in
+    reasonable ways as different from the original version; or
+
+    d) Limiting the use for publicity purposes of names of licensors or
+    authors of the material; or
+
+    e) Declining to grant rights under trademark law for use of some
+    trade names, trademarks, or service marks; or
+
+    f) Requiring indemnification of licensors and authors of that
+    material by anyone who conveys the material (or modified versions of
+    it) with contractual assumptions of liability to the recipient, for
+    any liability that these contractual assumptions directly impose on
+    those licensors and authors.
+
+  All other non-permissive additional terms are considered "further
+restrictions" within the meaning of section 10.  If the Program as you
+received it, or any part of it, contains a notice stating that it is
+governed by this License along with a term that is a further
+restriction, you may remove that term.  If a license document contains
+a further restriction but permits relicensing or conveying under this
+License, you may add to a covered work material governed by the terms
+of that license document, provided that the further restriction does
+not survive such relicensing or conveying.
+
+  If you add terms to a covered work in accord with this section, you
+must place, in the relevant source files, a statement of the
+additional terms that apply to those files, or a notice indicating
+where to find the applicable terms.
+
+  Additional terms, permissive or non-permissive, may be stated in the
+form of a separately written license, or stated as exceptions;
+the above requirements apply either way.
+
+  8. Termination.
+
+  You may not propagate or modify a covered work except as expressly
+provided under this License.  Any attempt otherwise to propagate or
+modify it is void, and will automatically terminate your rights under
+this License (including any patent licenses granted under the third
+paragraph of section 11).
+
+  However, if you cease all violation of this License, then your
+license from a particular copyright holder is reinstated (a)
+provisionally, unless and until the copyright holder explicitly and
+finally terminates your license, and (b) permanently, if the copyright
+holder fails to notify you of the violation by some reasonable means
+prior to 60 days after the cessation.
+
+  Moreover, your license from a particular copyright holder is
+reinstated permanently if the copyright holder notifies you of the
+violation by some reasonable means, this is the first time you have
+received notice of violation of this License (for any work) from that
+copyright holder, and you cure the violation prior to 30 days after
+your receipt of the notice.
+
+  Termination of your rights under this section does not terminate the
+licenses of parties who have received copies or rights from you under
+this License.  If your rights have been terminated and not permanently
+reinstated, you do not qualify to receive new licenses for the same
+material under section 10.
+
+  9. Acceptance Not Required for Having Copies.
+
+  You are not required to accept this License in order to receive or
+run a copy of the Program.  Ancillary propagation of a covered work
+occurring solely as a consequence of using peer-to-peer transmission
+to receive a copy likewise does not require acceptance.  However,
+nothing other than this License grants you permission to propagate or
+modify any covered work.  These actions infringe copyright if you do
+not accept this License.  Therefore, by modifying or propagating a
+covered work, you indicate your acceptance of this License to do so.
+
+  10. Automatic Licensing of Downstream Recipients.
+
+  Each time you convey a covered work, the recipient automatically
+receives a license from the original licensors, to run, modify and
+propagate that work, subject to this License.  You are not responsible
+for enforcing compliance by third parties with this License.
+
+  An "entity transaction" is a transaction transferring control of an
+organization, or substantially all assets of one, or subdividing an
+organization, or merging organizations.  If propagation of a covered
+work results from an entity transaction, each party to that
+transaction who receives a copy of the work also receives whatever
+licenses to the work the party's predecessor in interest had or could
+give under the previous paragraph, plus a right to possession of the
+Corresponding Source of the work from the predecessor in interest, if
+the predecessor has it or can get it with reasonable efforts.
+
+  You may not impose any further restrictions on the exercise of the
+rights granted or affirmed under this License.  For example, you may
+not impose a license fee, royalty, or other charge for exercise of
+rights granted under this License, and you may not initiate litigation
+(including a cross-claim or counterclaim in a lawsuit) alleging that
+any patent claim is infringed by making, using, selling, offering for
+sale, or importing the Program or any portion of it.
+
+  11. Patents.
+
+  A "contributor" is a copyright holder who authorizes use under this
+License of the Program or a work on which the Program is based.  The
+work thus licensed is called the contributor's "contributor version".
+
+  A contributor's "essential patent claims" are all patent claims
+owned or controlled by the contributor, whether already acquired or
+hereafter acquired, that would be infringed by some manner, permitted
+by this License, of making, using, or selling its contributor version,
+but do not include claims that would be infringed only as a
+consequence of further modification of the contributor version.  For
+purposes of this definition, "control" includes the right to grant
+patent sublicenses in a manner consistent with the requirements of
+this License.
+
+  Each contributor grants you a non-exclusive, worldwide, royalty-free
+patent license under the contributor's essential patent claims, to
+make, use, sell, offer for sale, import and otherwise run, modify and
+propagate the contents of its contributor version.
+
+  In the following three paragraphs, a "patent license" is any express
+agreement or commitment, however denominated, not to enforce a patent
+(such as an express permission to practice a patent or covenant not to
+sue for patent infringement).  To "grant" such a patent license to a
+party means to make such an agreement or commitment not to enforce a
+patent against the party.
+
+  If you convey a covered work, knowingly relying on a patent license,
+and the Corresponding Source of the work is not available for anyone
+to copy, free of charge and under the terms of this License, through a
+publicly available network server or other readily accessible means,
+then you must either (1) cause the Corresponding Source to be so
+available, or (2) arrange to deprive yourself of the benefit of the
+patent license for this particular work, or (3) arrange, in a manner
+consistent with the requirements of this License, to extend the patent
+license to downstream recipients.  "Knowingly relying" means you have
+actual knowledge that, but for the patent license, your conveying the
+covered work in a country, or your recipient's use of the covered work
+in a country, would infringe one or more identifiable patents in that
+country that you have reason to believe are valid.
+
+  If, pursuant to or in connection with a single transaction or
+arrangement, you convey, or propagate by procuring conveyance of, a
+covered work, and grant a patent license to some of the parties
+receiving the covered work authorizing them to use, propagate, modify
+or convey a specific copy of the covered work, then the patent license
+you grant is automatically extended to all recipients of the covered
+work and works based on it.
+
+  A patent license is "discriminatory" if it does not include within
+the scope of its coverage, prohibits the exercise of, or is
+conditioned on the non-exercise of one or more of the rights that are
+specifically granted under this License.  You may not convey a covered
+work if you are a party to an arrangement with a third party that is
+in the business of distributing software, under which you make payment
+to the third party based on the extent of your activity of conveying
+the work, and under which the third party grants, to any of the
+parties who would receive the covered work from you, a discriminatory
+patent license (a) in connection with copies of the covered work
+conveyed by you (or copies made from those copies), or (b) primarily
+for and in connection with specific products or compilations that
+contain the covered work, unless you entered into that arrangement,
+or that patent license was granted, prior to 28 March 2007.
+
+  Nothing in this License shall be construed as excluding or limiting
+any implied license or other defenses to infringement that may
+otherwise be available to you under applicable patent law.
+
+  12. No Surrender of Others' Freedom.
+
+  If conditions are imposed on you (whether by court order, agreement or
+otherwise) that contradict the conditions of this License, they do not
+excuse you from the conditions of this License.  If you cannot convey a
+covered work so as to satisfy simultaneously your obligations under this
+License and any other pertinent obligations, then as a consequence you may
+not convey it at all.  For example, if you agree to terms that obligate you
+to collect a royalty for further conveying from those to whom you convey
+the Program, the only way you could satisfy both those terms and this
+License would be to refrain entirely from conveying the Program.
+
+  13. Use with the GNU Affero General Public License.
+
+  Notwithstanding any other provision of this License, you have
+permission to link or combine any covered work with a work licensed
+under version 3 of the GNU Affero General Public License into a single
+combined work, and to convey the resulting work.  The terms of this
+License will continue to apply to the part which is the covered work,
+but the special requirements of the GNU Affero General Public License,
+section 13, concerning interaction through a network will apply to the
+combination as such.
+
+  14. Revised Versions of this License.
+
+  The Free Software Foundation may publish revised and/or new versions of
+the GNU General Public License from time to time.  Such new versions will
+be similar in spirit to the present version, but may differ in detail to
+address new problems or concerns.
+
+  Each version is given a distinguishing version number.  If the
+Program specifies that a certain numbered version of the GNU General
+Public License "or any later version" applies to it, you have the
+option of following the terms and conditions either of that numbered
+version or of any later version published by the Free Software
+Foundation.  If the Program does not specify a version number of the
+GNU General Public License, you may choose any version ever published
+by the Free Software Foundation.
+
+  If the Program specifies that a proxy can decide which future
+versions of the GNU General Public License can be used, that proxy's
+public statement of acceptance of a version permanently authorizes you
+to choose that version for the Program.
+
+  Later license versions may give you additional or different
+permissions.  However, no additional obligations are imposed on any
+author or copyright holder as a result of your choosing to follow a
+later version.
+
+  15. Disclaimer of Warranty.
+
+  THERE IS NO WARRANTY FOR THE PROGRAM, TO THE EXTENT PERMITTED BY
+APPLICABLE LAW.  EXCEPT WHEN OTHERWISE STATED IN WRITING THE COPYRIGHT
+HOLDERS AND/OR OTHER PARTIES PROVIDE THE PROGRAM "AS IS" WITHOUT WARRANTY
+OF ANY KIND, EITHER EXPRESSED OR IMPLIED, INCLUDING, BUT NOT LIMITED TO,
+THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+PURPOSE.  THE ENTIRE RISK AS TO THE QUALITY AND PERFORMANCE OF THE PROGRAM
+IS WITH YOU.  SHOULD THE PROGRAM PROVE DEFECTIVE, YOU ASSUME THE COST OF
+ALL NECESSARY SERVICING, REPAIR OR CORRECTION.
+
+  16. Limitation of Liability.
+
+  IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN WRITING
+WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MODIFIES AND/OR CONVEYS
+THE PROGRAM AS PERMITTED ABOVE, BE LIABLE TO YOU FOR DAMAGES, INCLUDING ANY
+GENERAL, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES ARISING OUT OF THE
+USE OR INABILITY TO USE THE PROGRAM (INCLUDING BUT NOT LIMITED TO LOSS OF
+DATA OR DATA BEING RENDERED INACCURATE OR LOSSES SUSTAINED BY YOU OR THIRD
+PARTIES OR A FAILURE OF THE PROGRAM TO OPERATE WITH ANY OTHER PROGRAMS),
+EVEN IF SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE POSSIBILITY OF
+SUCH DAMAGES.
+
+  17. Interpretation of Sections 15 and 16.
+
+  If the disclaimer of warranty and limitation of liability provided
+above cannot be given local legal effect according to their terms,
+reviewing courts shall apply local law that most closely approximates
+an absolute waiver of all civil liability in connection with the
+Program, unless a warranty or assumption of liability accompanies a
+copy of the Program in return for a fee.
+
+                     END OF TERMS AND CONDITIONS
+
+            How to Apply These Terms to Your New Programs
+
+  If you develop a new program, and you want it to be of the greatest
+possible use to the public, the best way to achieve this is to make it
+free software which everyone can redistribute and change under these terms.
+
+  To do so, attach the following notices to the program.  It is safest
+to attach them to the start of each source file to most effectively
+state the exclusion of warranty; and each file should have at least
+the "copyright" line and a pointer to where the full notice is found.
+
+    <one line to give the program's name and a brief idea of what it does.>
+    Copyright (C) <year>  <name of author>
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+Also add information on how to contact you by electronic and paper mail.
+
+  If the program does terminal interaction, make it output a short
+notice like this when it starts in an interactive mode:
+
+    <program>  Copyright (C) <year>  <name of author>
+    This program comes with ABSOLUTELY NO WARRANTY; for details type `show w'.
+    This is free software, and you are welcome to redistribute it
+    under certain conditions; type `show c' for details.
+
+The hypothetical commands `show w' and `show c' should show the appropriate
+parts of the General Public License.  Of course, your program's commands
+might be different; for a GUI interface, you would use an "about box".
+
+  You should also get your employer (if you work as a programmer) or school,
+if any, to sign a "copyright disclaimer" for the program, if necessary.
+For more information on this, and how to apply and follow the GNU GPL, see
+<https://www.gnu.org/licenses/>.
+
+  The GNU General Public License does not permit incorporating your program
+into proprietary programs.  If your program is a subroutine library, you
+may consider it more useful to permit linking proprietary applications with
+the library.  If this is what you want to do, use the GNU Lesser General
+Public License instead of this License.  But first, please read
+<https://www.gnu.org/licenses/why-not-lgpl.html>.

--- a/Makefile
+++ b/Makefile
@@ -5,10 +5,20 @@ BUILD_DATE ?= $(shell date -u +"%Y-%m-%d %H:%M:%S UTC")
 LDFLAGS    := -X 'main.version=$(VERSION)' -X 'main.commit=$(COMMIT)' -X 'main.buildDate=$(BUILD_DATE)'
 
 # External FAT implementations the tests validate our images against, so that
-# a self-consistently wrong filesystem cannot pass.
-REQUIRED_TOOLS := mdir mcopy fsck.fat
+# a self-consistently wrong filesystem cannot pass, plus the emulator the boot
+# test runs images on.
+REQUIRED_TOOLS := mdir mcopy fsck.fat qemu-system-x86_64
 
-.PHONY: help all build test unit integration tools-check vet fmt fmt-check check clean
+# The SYSLINUX release the boot test installs into an image. It is downloaded
+# rather than vendored because it is GPL-licensed and fatimg is Apache-2.0.
+SYSLINUX_VERSION := 6.03
+SYSLINUX_CACHE   := .syslinux
+SYSLINUX_DIR     := $(SYSLINUX_CACHE)/syslinux-$(SYSLINUX_VERSION)
+SYSLINUX_URL     := https://mirrors.edge.kernel.org/pub/linux/utils/boot/syslinux/syslinux-$(SYSLINUX_VERSION).tar.xz
+
+export FATIMG_SYSLINUX_DIR = $(abspath $(SYSLINUX_DIR))
+
+.PHONY: help all build test unit integration boot syslinux tools-check vet fmt fmt-check check clean
 
 help: ## Show this help
 	@grep -hE '^[a-z-]+:.*?## ' $(MAKEFILE_LIST) | awk -F':.*?## ' '{printf "  \033[36m%-12s\033[0m %s\n", $$1, $$2}'
@@ -22,16 +32,32 @@ build: ## Build the binary with version info
 # run time whether mtools and fsck.fat are installed, and Go's cache key does
 # not change when a tool appears in a directory already on PATH -- so a cached
 # run happily replays "skipping, not installed" after you have installed them.
-test: tools-check ## Run all tests, including image round-trips
+test: tools-check syslinux ## Run all tests, including image round-trips and the boot test
 	go test -count=1 ./...
 
 unit: ## Run only fast tests (no external tools needed)
 	go test -short ./...
 
-integration: tools-check ## Run image round-trip and external validation tests verbosely
+integration: tools-check syslinux ## Run image round-trip and external validation tests verbosely
 	go test -count=1 -v -run 'TestRoundTrip|TestList|TestCreate|TestGzip|TestMtools|TestFsck' ./...
 
-tools-check: ## Verify the external FAT validation tools are installed
+boot: tools-check syslinux ## Boot a --bios-boot image under QEMU
+	go test -count=1 -v -run TestBIOSBoot ./...
+
+syslinux: $(SYSLINUX_DIR) ## Download the SYSLINUX release the boot test installs
+
+# SYSLINUX is not vendored: it is GPL-2.0 and fatimg is Apache-2.0, and the
+# same reasoning keeps it out of the binary. The tarball ships the prebuilt
+# mbr.bin, ldlinux.bss, ldlinux.sys and ldlinux.c32 that an install needs;
+# most distribution packages do not, because their installer embeds them.
+$(SYSLINUX_DIR):
+	@echo "Downloading syslinux $(SYSLINUX_VERSION)..."
+	@mkdir -p $(SYSLINUX_CACHE)
+	@curl -sSfL $(SYSLINUX_URL) -o $(SYSLINUX_CACHE)/syslinux.tar.xz
+	@tar xf $(SYSLINUX_CACHE)/syslinux.tar.xz -C $(SYSLINUX_CACHE)
+	@rm -f $(SYSLINUX_CACHE)/syslinux.tar.xz
+
+tools-check: ## Verify the external validation tools are installed
 	@missing=""; \
 	for tool in $(REQUIRED_TOOLS); do \
 		command -v $$tool >/dev/null 2>&1 || missing="$$missing $$tool"; \
@@ -39,12 +65,12 @@ tools-check: ## Verify the external FAT validation tools are installed
 	if [ -n "$$missing" ]; then \
 		echo "Missing required tool(s):$$missing"; \
 		echo; \
-		echo "  macOS:   brew install mtools dosfstools"; \
-		echo "  Debian:  sudo apt-get install mtools dosfstools"; \
+		echo "  macOS:   brew install mtools dosfstools qemu"; \
+		echo "  Debian:  sudo apt-get install mtools dosfstools qemu-system-x86"; \
 		echo; \
-		echo "These provide the independent FAT implementations the tests"; \
-		echo "validate disk images against. See the Building and testing"; \
-		echo "section of README.md."; \
+		echo "mtools and dosfstools provide the independent FAT implementations"; \
+		echo "the tests validate disk images against; QEMU runs the boot test."; \
+		echo "See the Building and testing section of README.md."; \
 		echo; \
 		echo "To run only the tests that do not need them:  make unit"; \
 		exit 1; \
@@ -67,3 +93,4 @@ check: fmt-check vet test ## Everything CI runs
 clean: ## Remove build artifacts
 	rm -f $(BIN)
 	rm -rf dist/
+	rm -rf $(SYSLINUX_CACHE)

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ LDFLAGS    := -X 'main.version=$(VERSION)' -X 'main.commit=$(COMMIT)' -X 'main.b
 REQUIRED_TOOLS := mdir mcopy fsck.fat qemu-system-x86_64
 
 # The SYSLINUX release the boot test installs into an image. It is downloaded
-# rather than vendored because it is GPL-licensed and fatimg is Apache-2.0.
+# rather than vendored so that we do not redistribute someone else's binaries.
 SYSLINUX_VERSION := 6.03
 SYSLINUX_CACHE   := .syslinux
 SYSLINUX_DIR     := $(SYSLINUX_CACHE)/syslinux-$(SYSLINUX_VERSION)
@@ -41,13 +41,14 @@ unit: ## Run only fast tests (no external tools needed)
 integration: tools-check syslinux ## Run image round-trip and external validation tests verbosely
 	go test -count=1 -v -run 'TestRoundTrip|TestList|TestCreate|TestGzip|TestMtools|TestFsck' ./...
 
-boot: tools-check syslinux ## Boot a --bios-boot image under QEMU
+boot: tools-check syslinux ## Boot a --syslinux image under QEMU
 	go test -count=1 -v -run TestBIOSBoot ./...
 
 syslinux: $(SYSLINUX_DIR) ## Download the SYSLINUX release the boot test installs
 
-# SYSLINUX is not vendored: it is GPL-2.0 and fatimg is Apache-2.0, and the
-# same reasoning keeps it out of the binary. The tarball ships the prebuilt
+# SYSLINUX is not vendored: shipping someone else's binaries inside ours would
+# mean carrying their version skew and redistribution obligations, and the same
+# reasoning keeps it out of the binary. The tarball ships the prebuilt
 # mbr.bin, ldlinux.bss, ldlinux.sys and ldlinux.c32 that an install needs;
 # most distribution packages do not, because their installer embeds them.
 $(SYSLINUX_DIR):

--- a/README.md
+++ b/README.md
@@ -10,8 +10,11 @@ fatimg can create, extract, and list files on the first partition (which must be
 
 The disk image file can optionally be gzipped, in which case fatimg will automatically gunzip it to a tmp file.
 
-WARNING: there will probably be breaking changes as I intend to extend it to support legacy boot images with MBR,
-as well as GPT (so additional cli flags to specify what is now assumed defaults).
+With `--bios-boot` it can also make the image bootable by a legacy BIOS, by installing SYSLINUX. See
+[Legacy BIOS boot](#legacy-bios-boot) below.
+
+WARNING: there will probably be breaking changes as I intend to extend it to support GPT
+(so additional cli flags to specify what is now assumed defaults).
 
 ## Installation
 
@@ -40,27 +43,35 @@ Building needs nothing but a Go toolchain:
 make build
 ```
 
-Running the tests additionally requires **mtools** and **dosfstools**:
+Running the tests additionally requires **mtools**, **dosfstools** and **QEMU**:
 
 ```bash
 # macOS
-brew install mtools dosfstools
+brew install mtools dosfstools qemu
 
 # Debian/Ubuntu
-sudo apt-get install mtools dosfstools
+sudo apt-get install mtools dosfstools qemu-system-x86
 ```
 
-These provide `mdir`, `mcopy` and `fsck.fat`. The tests use them to check that
-disk images are valid according to independent FAT implementations, rather than
-only checking that fatimg agrees with itself — a filesystem can be
-self-consistent and still be wrong. They are a hard requirement: if a tool is
-missing the tests fail rather than skip, because a skipped check is
-indistinguishable from a passing one.
+The first two provide `mdir`, `mcopy` and `fsck.fat`. The tests use them to
+check that disk images are valid according to independent FAT implementations,
+rather than only checking that fatimg agrees with itself — a filesystem can be
+self-consistent and still be wrong. QEMU is used by the boot test, which builds
+a `--bios-boot` image and runs it on an emulated PC; no filesystem check can
+tell you whether a bootloader install worked, because a boot sector is not part
+of the filesystem. They are a hard requirement: if a tool is missing the tests
+fail rather than skip, because a skipped check is indistinguishable from a
+passing one.
+
+The boot test also needs a SYSLINUX release to install. `make` downloads one
+into `.syslinux/` for you; it is not vendored because SYSLINUX is GPL-licensed
+and fatimg is Apache-2.0.
 
 ```bash
 make test         # everything (fails early if a tool is missing)
 make unit         # only the tests that need no external tools
 make integration  # round-trip and validation tests, verbose
+make boot         # boot a --bios-boot image under QEMU, verbose
 make check        # what CI runs: gofmt, vet, tests
 make help         # list all targets
 ```
@@ -70,7 +81,7 @@ make help         # list all targets
 ### Create a disk image
 
 ```
-Create a disk image with an EFI partition.
+Create a disk image with a FAT32 partition.
 
 The contents of the partition are specified as a list of one or more paths.
 Folders are copied recursively, and include the folder name itself
@@ -80,14 +91,20 @@ Usage:
   fatimg create [options] <path> [<path> ...]
 
 Options:
+  -bios-boot
+    	make the image bootable by a legacy BIOS, using SYSLINUX
   -gzip
     	compress output file with gzip (automatic if output ends with '.gz')
   -label string
     	EFI partition volume label (default "boot")
   -output string
     	output path (required)
+  -part-type string
+    	MBR partition type, "efi" or "fat32" (default "efi")
   -size int
     	partition size in megabytes (default 1024)
+  -syslinux-dir string
+    	directory holding the SYSLINUX release to install (required with --bios-boot)
   -trim
     	trim disk image before compressing (truncate zero-filled sectors at the end)
 ```
@@ -97,6 +114,39 @@ Example:
 # Create a compressed 512MB disk image with label "BOOT"
 fatimg create --output boot.img.gz --size 512 --label BOOT ./EFI/
 ```
+
+### Legacy BIOS boot
+
+`--bios-boot` installs SYSLINUX into the image so a PC BIOS will boot it:
+the SYSLINUX MBR bootstrap in sector 0, its boot sector merged into the
+partition, and `ldlinux.sys` and `ldlinux.c32` written to the filesystem root.
+You supply the `syslinux.cfg`, as one of the paths copied in.
+
+```bash
+fatimg create --output disk.img --size 512 \
+    --bios-boot --syslinux-dir ~/syslinux-6.03 --part-type fat32 ./boot/
+```
+
+SYSLINUX is not bundled with fatimg — it is GPL-licensed and fatimg is
+Apache-2.0 — so `--syslinux-dir` has to point at your own copy. It needs
+`mbr.bin`, `ldlinux.bss`, `ldlinux.sys` and `ldlinux.c32`, and they should all
+come from the same release. An unpacked
+[syslinux release tarball](https://mirrors.edge.kernel.org/pub/linux/utils/boot/syslinux/)
+works as-is: the tarball ships them prebuilt. Most distribution packages do
+**not**, because their `syslinux` installer has `ldlinux.bss` and `ldlinux.sys`
+linked into the binary rather than shipped as files.
+
+Two things to know:
+
+- `--part-type fat32` writes partition type `0x0c` instead of the default EFI
+  system partition (`0xef`). Both boot on a normal BIOS, which goes by the
+  active flag rather than the type byte, but `0x0c` is the conventional choice
+  for a BIOS-only image and some firmware is fussier than others.
+- The partition has to be large enough to be a real FAT32 — more than 65524
+  clusters, which in practice means `--size 33` or above. Below that, SYSLINUX
+  applies the standard rule and reads the filesystem as FAT16, and the boot
+  stops after printing its banner. fatimg refuses to build such an image rather
+  than let you find out at boot time.
 
 ### List contents
 

--- a/README.md
+++ b/README.md
@@ -64,8 +64,7 @@ fail rather than skip, because a skipped check is indistinguishable from a
 passing one.
 
 The boot test also needs a SYSLINUX release to install. `make` downloads one
-into `.syslinux/` for you; it is not vendored because SYSLINUX is GPL-licensed
-and fatimg is Apache-2.0.
+into `.syslinux/` for you rather than vendoring it into the repository.
 
 ```bash
 make test         # everything (fails early if a tool is missing)
@@ -127,10 +126,9 @@ fatimg create --output disk.img --size 512 \
     --syslinux --syslinux-dir ~/syslinux-6.03 --part-type fat32 ./boot/
 ```
 
-SYSLINUX is not bundled with fatimg — it is GPL-licensed and fatimg is
-Apache-2.0 — so `--syslinux-dir` has to point at your own copy. It needs
-`mbr.bin`, `ldlinux.bss`, `ldlinux.sys` and `ldlinux.c32`, and they should all
-come from the same release. An unpacked
+SYSLINUX is not bundled with fatimg, so `--syslinux-dir` has to point at your
+own copy. It needs `mbr.bin`, `ldlinux.bss`, `ldlinux.sys` and `ldlinux.c32`,
+and they should all come from the same release. An unpacked
 [syslinux release tarball](https://mirrors.edge.kernel.org/pub/linux/utils/boot/syslinux/)
 works as-is: the tarball ships them prebuilt. Most distribution packages do
 **not**, because their `syslinux` installer has `ldlinux.bss` and `ldlinux.sys`
@@ -203,3 +201,18 @@ Writing ./extracted/system/rootfs.squashfs (149.1 MB)
 rootfs.squashfs: 100.0% (523.1 MB/s, ~0s remaining)
 ```
 
+## License
+
+fatimg is licensed under the [GNU General Public License, version 3 or
+later](LICENSE).
+
+It was previously Apache-2.0. The BIOS boot support in `boot.go` is derived
+from [SYSLINUX](https://www.syslinux.org/) — `syslinux_patch()` and
+`generate_extents()` in `libinstaller/syslxmod.c`, and `cleanup_adv()` in
+`libinstaller/setadv.c`, copyright 1998-2008 H. Peter Anvin and 2009-2014 Intel
+Corporation. Those are GPL-2.0-or-later, so the project moved to GPLv3 rather
+than misrepresent what it is. Releases up to and including the last Apache-2.0
+tag remain available under those terms.
+
+SYSLINUX itself is not distributed with fatimg, in source or binary form. The
+dependencies are all MIT or BSD licensed.

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ fatimg can create, extract, and list files on the first partition (which must be
 
 The disk image file can optionally be gzipped, in which case fatimg will automatically gunzip it to a tmp file.
 
-With `--bios-boot` it can also make the image bootable by a legacy BIOS, by installing SYSLINUX. See
+With `--syslinux` it can also make the image bootable by a legacy BIOS, by installing SYSLINUX. See
 [Legacy BIOS boot](#legacy-bios-boot) below.
 
 WARNING: there will probably be breaking changes as I intend to extend it to support GPT
@@ -57,7 +57,7 @@ The first two provide `mdir`, `mcopy` and `fsck.fat`. The tests use them to
 check that disk images are valid according to independent FAT implementations,
 rather than only checking that fatimg agrees with itself — a filesystem can be
 self-consistent and still be wrong. QEMU is used by the boot test, which builds
-a `--bios-boot` image and runs it on an emulated PC; no filesystem check can
+a `--syslinux` image and runs it on an emulated PC; no filesystem check can
 tell you whether a bootloader install worked, because a boot sector is not part
 of the filesystem. They are a hard requirement: if a tool is missing the tests
 fail rather than skip, because a skipped check is indistinguishable from a
@@ -71,7 +71,7 @@ and fatimg is Apache-2.0.
 make test         # everything (fails early if a tool is missing)
 make unit         # only the tests that need no external tools
 make integration  # round-trip and validation tests, verbose
-make boot         # boot a --bios-boot image under QEMU, verbose
+make boot         # boot a --syslinux image under QEMU, verbose
 make check        # what CI runs: gofmt, vet, tests
 make help         # list all targets
 ```
@@ -91,8 +91,6 @@ Usage:
   fatimg create [options] <path> [<path> ...]
 
 Options:
-  -bios-boot
-    	make the image bootable by a legacy BIOS, using SYSLINUX
   -gzip
     	compress output file with gzip (automatic if output ends with '.gz')
   -label string
@@ -103,8 +101,10 @@ Options:
     	MBR partition type, "efi" or "fat32" (default "efi")
   -size int
     	partition size in megabytes (default 1024)
+  -syslinux
+    	make the image bootable by a legacy BIOS, using SYSLINUX
   -syslinux-dir string
-    	directory holding the SYSLINUX release to install (required with --bios-boot)
+    	directory holding the SYSLINUX release to install (required with --syslinux)
   -trim
     	trim disk image before compressing (truncate zero-filled sectors at the end)
 ```
@@ -117,14 +117,14 @@ fatimg create --output boot.img.gz --size 512 --label BOOT ./EFI/
 
 ### Legacy BIOS boot
 
-`--bios-boot` installs SYSLINUX into the image so a PC BIOS will boot it:
+`--syslinux` installs SYSLINUX into the image so a PC BIOS will boot it:
 the SYSLINUX MBR bootstrap in sector 0, its boot sector merged into the
 partition, and `ldlinux.sys` and `ldlinux.c32` written to the filesystem root.
 You supply the `syslinux.cfg`, as one of the paths copied in.
 
 ```bash
 fatimg create --output disk.img --size 512 \
-    --bios-boot --syslinux-dir ~/syslinux-6.03 --part-type fat32 ./boot/
+    --syslinux --syslinux-dir ~/syslinux-6.03 --part-type fat32 ./boot/
 ```
 
 SYSLINUX is not bundled with fatimg — it is GPL-licensed and fatimg is

--- a/boot.go
+++ b/boot.go
@@ -1,0 +1,606 @@
+package main
+
+// Legacy (BIOS) boot support, via SYSLINUX.
+//
+// Making a FAT32 image bootable by a PC BIOS takes four things beyond the
+// filesystem itself:
+//
+//  1. mbr.bin in the first 440 bytes of sector 0, to chainload the partition
+//     marked active;
+//  2. a BPB whose hidden-sector count is the partition's LBA — the SYSLINUX
+//     boot sector adds it to every filesystem-relative sector it reads, so a
+//     zero there sends it to the wrong end of the disk;
+//  3. the SYSLINUX boot sector (ldlinux.bss) merged into the partition's
+//     first sector, leaving the BPB in place;
+//  4. ldlinux.sys on the filesystem, patched with the list of disk sectors it
+//     occupies. 512 bytes of boot sector cannot walk a FAT chain, so the
+//     sector map is stamped in at install time.
+//
+// Item 4 is the whole of the work, and this file follows syslinux_patch() in
+// syslinux-6.03 libinstaller/syslxmod.c. The structure offsets below are a
+// property of the ldlinux.sys build being installed, not of the format, which
+// is why they are read out of the image rather than hardcoded, and why the
+// files must come from one syslinux release rather than a mix.
+
+import (
+	"encoding/binary"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+const (
+	// ldlinuxMagic marks the patch area inside ldlinux.sys.
+	ldlinuxMagic = 0x3eb202fe
+
+	// ldlinuxLoadAddr is where the boot sector loads ldlinux.sys. Extents
+	// are split so that no single one straddles a 64K boundary from here.
+	ldlinuxLoadAddr = 0x8000
+
+	// extentSize is sizeof(struct syslinux_extent): a 64-bit LBA and a
+	// 16-bit sector count, packed.
+	extentSize = 10
+
+	// advSize is the size of one Auxiliary Data Vector. Two of them are
+	// appended to ldlinux.sys on disk.
+	advSize   = 512
+	advMagic1 = 0x5a2d2fa5
+	advMagic2 = 0xa3041767
+	advMagic3 = 0xdd28bf64
+
+	// ldlinuxName is the 8.3 short name of ldlinux.sys in the root
+	// directory, as it appears in the directory entry.
+	ldlinuxName = "LDLINUX SYS"
+
+	// mbrBootstrapSize is the space before the disk signature and partition
+	// table in sector 0.
+	mbrBootstrapSize = 440
+
+	// bpbHiddenSectorsOffset is the offset of the 32-bit hidden-sector
+	// count within a FAT boot sector.
+	bpbHiddenSectorsOffset = 0x1c
+	// bpbGeometryOffset is the offset of the 16-bit sectors-per-track
+	// field, immediately followed by the head count.
+	bpbGeometryOffset = 0x18
+	// fatBackupBootSector is where go-diskfs mirrors the boot sector.
+	fatBackupBootSector = 6
+
+	// The two regions of a FAT32 boot sector that belong to SYSLINUX rather
+	// than to the filesystem: the jump and OEM name, and the boot code. The
+	// BPB between them, and the 0x55AA signature after it, are preserved.
+	// From FAT_bsHead/FAT_bsCode in libinstaller/syslxint.h.
+	bsHeadStart, bsHeadEnd = 0, 11
+	bsCodeStart, bsCodeEnd = 90, 510
+)
+
+// syslinuxFiles holds the pieces of a SYSLINUX release needed for a BIOS boot.
+type syslinuxFiles struct {
+	mbr      []byte // mbr.bin, the 440-byte MBR bootstrap
+	bootSect []byte // ldlinux.bss, the 512-byte FAT boot sector template
+	ldlinux  []byte // ldlinux.sys, the core loaded by the boot sector
+	c32      []byte // ldlinux.c32, the module ldlinux.sys loads in turn
+}
+
+// syslinuxSearchDirs are the subdirectories of --syslinux-dir searched for
+// each file. The list covers an unpacked syslinux tarball as well as the
+// layouts the common distribution packages use.
+var syslinuxSearchDirs = []string{
+	".",
+	"bios",
+	"core",
+	"mbr",
+	"bios/core",
+	"bios/mbr",
+	"modules/bios",
+	"bios/com32/elflink/ldlinux",
+	"com32/elflink/ldlinux",
+}
+
+func findSyslinuxFile(dir, name string) ([]byte, error) {
+	for _, sub := range syslinuxSearchDirs {
+		b, err := os.ReadFile(filepath.Join(dir, sub, name))
+		if err == nil {
+			return b, nil
+		}
+		if !os.IsNotExist(err) {
+			return nil, err
+		}
+	}
+	return nil, fmt.Errorf("%s not found under %s (searched %s)",
+		name, dir, strings.Join(syslinuxSearchDirs, ", "))
+}
+
+// loadSyslinuxFiles reads the SYSLINUX files out of dir, which should be a
+// syslinux release directory. The files are not embedded in fatimg because
+// SYSLINUX is GPL-2.0 and fatimg is Apache-2.0.
+func loadSyslinuxFiles(dir string) (*syslinuxFiles, error) {
+	s := &syslinuxFiles{}
+	for _, f := range []struct {
+		name string
+		dest *[]byte
+	}{
+		{"mbr.bin", &s.mbr},
+		{"ldlinux.bss", &s.bootSect},
+		{"ldlinux.sys", &s.ldlinux},
+		{"ldlinux.c32", &s.c32},
+	} {
+		b, err := findSyslinuxFile(dir, f.name)
+		if err != nil {
+			return nil, err
+		}
+		*f.dest = b
+	}
+	// mbr.bin has to stop short of the partition table at offset 446, and
+	// the boot sector template has to be exactly one sector. Anything else
+	// means the wrong file was picked up.
+	if len(s.mbr) > mbrBootstrapSize {
+		return nil, fmt.Errorf("mbr.bin is %d bytes, expected at most %d", len(s.mbr), mbrBootstrapSize)
+	}
+	if len(s.bootSect) != BlockSize {
+		return nil, fmt.Errorf("ldlinux.bss is %d bytes, expected %d", len(s.bootSect), BlockSize)
+	}
+	if len(s.ldlinux) < BlockSize {
+		return nil, fmt.Errorf("ldlinux.sys is %d bytes, which is too small to be valid", len(s.ldlinux))
+	}
+	return s, nil
+}
+
+// ldlinuxSectors is the number of sectors ldlinux.sys occupies on disk,
+// including the two ADV sectors appended to it.
+func ldlinuxSectors(ldlinuxLen int) int {
+	return (ldlinuxLen+BlockSize-1)/BlockSize + 2
+}
+
+// ldlinuxPayload is the byte stream written to the filesystem as
+// /ldlinux.sys: the image followed by two ADV sectors, padded out to a whole
+// number of sectors so that the patched copy can be written back in place.
+func ldlinuxPayload(ldlinux []byte) []byte {
+	buf := make([]byte, ldlinuxSectors(len(ldlinux))*BlockSize)
+	copy(buf, ldlinux)
+	copy(buf[len(ldlinux):], makeADV())
+	return buf
+}
+
+// makeADV builds the pair of empty Auxiliary Data Vectors that SYSLINUX keeps
+// at the end of ldlinux.sys, following syslinux_reset_adv() and cleanup_adv()
+// in libinstaller/setadv.c. The two copies are identical.
+func makeADV() []byte {
+	adv := make([]byte, 2*advSize)
+	binary.LittleEndian.PutUint32(adv[0:4], advMagic1)
+	csum := uint32(advMagic2)
+	for i := 8; i < advSize-4; i += 4 {
+		csum -= binary.LittleEndian.Uint32(adv[i : i+4])
+	}
+	binary.LittleEndian.PutUint32(adv[4:8], csum)
+	binary.LittleEndian.PutUint32(adv[advSize-4:advSize], advMagic3)
+	copy(adv[advSize:], adv[:advSize])
+	return adv
+}
+
+// patchArea locates the patch area inside ldlinux.sys and reads the offsets
+// of the extended patch area out of it. All offsets are relative to the start
+// of the image except sect1ptr0 and sect1ptr1, which are offsets into the
+// boot sector.
+type patchArea struct {
+	offset int // of the patch area itself
+
+	epa          int
+	advPtrOffset int
+	dirOffset    int
+	dirLen       int
+	secPtrOffset int
+	secPtrCount  int
+	sect1Ptr0    int
+	sect1Ptr1    int
+}
+
+func findPatchArea(img []byte) (*patchArea, error) {
+	p := -1
+	for i := 0; i+4 <= len(img); i += 4 {
+		if binary.LittleEndian.Uint32(img[i:i+4]) == ldlinuxMagic {
+			p = i
+			break
+		}
+	}
+	if p < 0 {
+		return nil, fmt.Errorf("no patch area found in ldlinux.sys (is it a SYSLINUX BIOS build?)")
+	}
+	// The patch area is 24 bytes; epaoffset is its last field.
+	if p+24 > len(img) {
+		return nil, fmt.Errorf("patch area at offset %d is truncated", p)
+	}
+	u16 := func(off int) int { return int(binary.LittleEndian.Uint16(img[off : off+2])) }
+
+	epa := u16(p + 22)
+	if epa+20 > len(img) {
+		return nil, fmt.Errorf("extended patch area at offset %d is out of range", epa)
+	}
+	pa := &patchArea{
+		offset:       p,
+		epa:          epa,
+		advPtrOffset: u16(epa + 0),
+		dirOffset:    u16(epa + 2),
+		dirLen:       u16(epa + 4),
+		secPtrOffset: u16(epa + 10),
+		secPtrCount:  u16(epa + 12),
+		sect1Ptr0:    u16(epa + 14),
+		sect1Ptr1:    u16(epa + 16),
+	}
+
+	// The offsets come from the file rather than from us, so check that
+	// every region they describe is inside it before writing through them.
+	// ldlinux.sys is whatever the user pointed --syslinux-dir at.
+	for _, r := range []struct {
+		name       string
+		start, end int
+	}{
+		{"ADV pointers", pa.advPtrOffset, pa.advPtrOffset + 16},
+		{"install directory", pa.dirOffset, pa.dirOffset + pa.dirLen},
+		{"sector extents", pa.secPtrOffset, pa.secPtrOffset + pa.secPtrCount*extentSize},
+	} {
+		if r.start < 0 || r.end > len(img) {
+			return nil, fmt.Errorf("%s at offset %d..%d lie outside ldlinux.sys (%d bytes)",
+				r.name, r.start, r.end, len(img))
+		}
+	}
+	// These index the boot sector, not the image.
+	for _, r := range []struct {
+		name   string
+		offset int
+	}{
+		{"first sector pointer", pa.sect1Ptr0},
+		{"first sector pointer (high)", pa.sect1Ptr1},
+	} {
+		if r.offset < 0 || r.offset+4 > BlockSize {
+			return nil, fmt.Errorf("%s at offset %d lies outside the boot sector", r.name, r.offset)
+		}
+	}
+	return pa, nil
+}
+
+// patchLdlinux stamps the sector map into ldlinux.sys and into the boot sector
+// template, following syslinux_patch() in libinstaller/syslxmod.c. Both img
+// and bootSect are modified in place. img is the padded payload from
+// ldlinuxPayload; ldlinuxLen is the unpadded length of ldlinux.sys, which is
+// what the totals and the checksum are computed over. sectors are
+// filesystem-relative sector numbers, in file order.
+func patchLdlinux(img, bootSect []byte, ldlinuxLen int, sectors []uint64) error {
+	nsect := ldlinuxSectors(ldlinuxLen)
+	if len(sectors) < nsect {
+		return fmt.Errorf("ldlinux.sys occupies %d sectors, need %d", len(sectors), nsect)
+	}
+	pa, err := findPatchArea(img)
+	if err != nil {
+		return err
+	}
+
+	// The boot sector loads the first sector of ldlinux.sys itself, and
+	// finds the rest through the extents below.
+	binary.LittleEndian.PutUint32(bootSect[pa.sect1Ptr0:], uint32(sectors[0]))
+	binary.LittleEndian.PutUint32(bootSect[pa.sect1Ptr1:], uint32(sectors[0]>>32))
+
+	dwords := ldlinuxLen >> 2 // complete dwords, excluding the ADVs
+	binary.LittleEndian.PutUint16(img[pa.offset+8:], uint16(nsect-2))
+	binary.LittleEndian.PutUint16(img[pa.offset+10:], 2)
+	binary.LittleEndian.PutUint32(img[pa.offset+12:], uint32(dwords))
+
+	// Everything between the first sector and the two ADVs is described by
+	// the extent list.
+	extents, err := generateExtents(sectors[1:nsect-2], pa.secPtrCount)
+	if err != nil {
+		return err
+	}
+	clear(img[pa.secPtrOffset : pa.secPtrOffset+pa.secPtrCount*extentSize])
+	copy(img[pa.secPtrOffset:], extents)
+
+	binary.LittleEndian.PutUint64(img[pa.advPtrOffset:], sectors[nsect-2])
+	binary.LittleEndian.PutUint64(img[pa.advPtrOffset+8:], sectors[nsect-1])
+
+	// Install into the root directory. dirlen includes the NUL.
+	if pa.dirLen < 2 {
+		return fmt.Errorf("no room for the install directory in ldlinux.sys")
+	}
+	img[pa.dirOffset] = '/'
+	img[pa.dirOffset+1] = 0
+
+	// The checksum is negative: ldlinux.sys sums its own dwords at boot and
+	// expects the magic back.
+	binary.LittleEndian.PutUint32(img[pa.offset+16:], 0)
+	csum := uint32(ldlinuxMagic)
+	for i := range dwords {
+		csum -= binary.LittleEndian.Uint32(img[i*4 : i*4+4])
+	}
+	binary.LittleEndian.PutUint32(img[pa.offset+16:], csum)
+	return nil
+}
+
+// generateExtents packs a list of sectors into (lba, count) extents, merging
+// runs that are contiguous on disk. A run is broken when the corresponding
+// load address would cross a 64K boundary, since the boot sector reads through
+// a real-mode segmented address. Follows generate_extents() in syslxmod.c.
+func generateExtents(sectors []uint64, maxExtents int) ([]byte, error) {
+	out := make([]byte, 0, len(sectors)*extentSize)
+	addr := uint32(ldlinuxLoadAddr)
+	base := addr
+	var lba uint64
+	var length uint32
+
+	emit := func() {
+		var e [extentSize]byte
+		binary.LittleEndian.PutUint64(e[0:8], lba)
+		binary.LittleEndian.PutUint16(e[8:10], uint16(length))
+		out = append(out, e[:]...)
+	}
+
+	for _, sect := range sectors {
+		if length != 0 {
+			xbytes := (length + 1) * BlockSize
+			if sect == lba+uint64(length) && xbytes < 65536 &&
+				(addr^(base+xbytes-1))&0xffff0000 == 0 {
+				length++
+				addr += BlockSize
+				continue
+			}
+			emit()
+		}
+		base = addr
+		lba = sect
+		length = 1
+		addr += BlockSize
+	}
+	if length != 0 {
+		emit()
+	}
+
+	if n := len(out) / extentSize; n > maxExtents {
+		return nil, fmt.Errorf("ldlinux.sys is too fragmented: %d extents, ldlinux.sys has room for %d", n, maxExtents)
+	}
+	return out, nil
+}
+
+// fatLayout is the part of the FAT32 BPB needed to turn a cluster number into
+// a sector number relative to the start of the partition.
+type fatLayout struct {
+	sectorsPerCluster uint32
+	reservedSectors   uint32
+	fatCount          uint32
+	sectorsPerFat     uint32
+	rootCluster       uint32
+	totalSectors      uint32
+}
+
+func (l fatLayout) firstDataSector() uint32 {
+	return l.reservedSectors + l.fatCount*l.sectorsPerFat
+}
+
+func (l fatLayout) clusterSector(c uint32) uint32 {
+	return l.firstDataSector() + (c-2)*l.sectorsPerCluster
+}
+
+// clusterCount is the number of data clusters in the filesystem, which is what
+// decides whether a reader treats it as FAT16 or FAT32.
+func (l fatLayout) clusterCount() uint32 {
+	return (l.totalSectors - l.firstDataSector()) / l.sectorsPerCluster
+}
+
+// fat32MinClusters is the largest cluster count that still reads as FAT16.
+// A filesystem at or below it is not really FAT32 no matter what its BPB says;
+// see clusters <= 0xfff4 in syslinux core/fs/fat/fat.c.
+const fat32MinClusters = 0xfff4
+
+func readFATLayout(img *os.File, partOffset int64) (fatLayout, error) {
+	bs := make([]byte, BlockSize)
+	if _, err := img.ReadAt(bs, partOffset); err != nil {
+		return fatLayout{}, fmt.Errorf("error reading FAT boot sector: %w", err)
+	}
+	if bps := binary.LittleEndian.Uint16(bs[11:13]); bps != BlockSize {
+		return fatLayout{}, fmt.Errorf("unsupported FAT sector size %d", bps)
+	}
+	l := fatLayout{
+		sectorsPerCluster: uint32(bs[13]),
+		reservedSectors:   uint32(binary.LittleEndian.Uint16(bs[14:16])),
+		fatCount:          uint32(bs[16]),
+		sectorsPerFat:     binary.LittleEndian.Uint32(bs[36:40]),
+		rootCluster:       binary.LittleEndian.Uint32(bs[44:48]),
+		totalSectors:      binary.LittleEndian.Uint32(bs[32:36]),
+	}
+	if l.sectorsPerCluster == 0 || l.fatCount == 0 || l.sectorsPerFat == 0 || l.rootCluster < 2 {
+		return fatLayout{}, fmt.Errorf("first partition does not hold a FAT32 filesystem")
+	}
+	return l, nil
+}
+
+// fatEOC is the first cluster value that terminates a chain; the top four bits
+// of a FAT32 entry are reserved.
+const fatEOC = 0x0ffffff8
+
+// maxChainClusters bounds the walk so that a corrupt FAT cannot loop forever.
+const maxChainClusters = 1 << 20
+
+// chain follows a FAT32 cluster chain from start.
+func (l fatLayout) chain(img *os.File, partOffset int64, start uint32) ([]uint32, error) {
+	fatOffset := partOffset + int64(l.reservedSectors)*BlockSize
+	var out []uint32
+	var buf [4]byte
+	for c := start; c >= 2 && c < fatEOC; {
+		out = append(out, c)
+		if len(out) > maxChainClusters {
+			return nil, fmt.Errorf("cluster chain from %d does not terminate", start)
+		}
+		if _, err := img.ReadAt(buf[:], fatOffset+int64(c)*4); err != nil {
+			return nil, fmt.Errorf("error reading FAT: %w", err)
+		}
+		c = binary.LittleEndian.Uint32(buf[:]) & 0x0fffffff
+	}
+	return out, nil
+}
+
+// findRootEntry returns the first cluster of a file in the root directory,
+// looked up by its 11-byte 8.3 short name.
+func (l fatLayout) findRootEntry(img *os.File, partOffset int64, shortName string) (uint32, error) {
+	clusters, err := l.chain(img, partOffset, l.rootCluster)
+	if err != nil {
+		return 0, err
+	}
+	buf := make([]byte, l.sectorsPerCluster*BlockSize)
+	for _, c := range clusters {
+		off := partOffset + int64(l.clusterSector(c))*BlockSize
+		if _, err := img.ReadAt(buf, off); err != nil {
+			return 0, fmt.Errorf("error reading root directory: %w", err)
+		}
+		for i := 0; i+32 <= len(buf); i += 32 {
+			e := buf[i : i+32]
+			switch {
+			case e[0] == 0x00: // end of directory
+				return 0, fmt.Errorf("%s not found in the root directory", shortName)
+			case e[0] == 0xe5: // deleted
+				continue
+			case e[11] == 0x0f: // long file name fragment
+				continue
+			}
+			if string(e[0:11]) == shortName {
+				hi := uint32(binary.LittleEndian.Uint16(e[20:22]))
+				lo := uint32(binary.LittleEndian.Uint16(e[26:28]))
+				return hi<<16 | lo, nil
+			}
+		}
+	}
+	return 0, fmt.Errorf("%s not found in the root directory", shortName)
+}
+
+// ldlinuxSectorMap returns the first n filesystem-relative sectors of the
+// already-written /ldlinux.sys.
+func ldlinuxSectorMap(img *os.File, partOffset int64, l fatLayout, n int) ([]uint64, error) {
+	start, err := l.findRootEntry(img, partOffset, ldlinuxName)
+	if err != nil {
+		return nil, err
+	}
+	clusters, err := l.chain(img, partOffset, start)
+	if err != nil {
+		return nil, err
+	}
+	sectors := make([]uint64, 0, n)
+	for _, c := range clusters {
+		first := l.clusterSector(c)
+		for j := uint32(0); j < l.sectorsPerCluster && len(sectors) < n; j++ {
+			sectors = append(sectors, uint64(first+j))
+		}
+		if len(sectors) == n {
+			break
+		}
+	}
+	if len(sectors) < n {
+		return nil, fmt.Errorf("ldlinux.sys is %d sectors on disk, expected %d", len(sectors), n)
+	}
+	return sectors, nil
+}
+
+// fixBPBGeometry corrects the two BPB fields go-diskfs fills in with
+// placeholders: the hidden-sector count, which it always writes as zero, and
+// the CHS geometry, which it writes as 1/1 on the grounds that everything uses
+// LBA. Both are wrong for a filesystem inside a partition, and SYSLINUX needs
+// the first of them to find anything at all.
+//
+// The backup boot sector is corrected too, so that it stays a copy.
+func fixBPBGeometry(img *os.File, partStart int64) error {
+	for _, sector := range []int64{0, fatBackupBootSector} {
+		base := (partStart + sector) * BlockSize
+
+		var hidden [4]byte
+		binary.LittleEndian.PutUint32(hidden[:], uint32(partStart))
+		if _, err := img.WriteAt(hidden[:], base+bpbHiddenSectorsOffset); err != nil {
+			return fmt.Errorf("error writing hidden sector count: %w", err)
+		}
+
+		// 63 sectors per track, 255 heads: the conventional fiction, and
+		// what a CHS fallback in a boot sector expects to see.
+		var geom [4]byte
+		binary.LittleEndian.PutUint16(geom[0:2], 63)
+		binary.LittleEndian.PutUint16(geom[2:4], 255)
+		if _, err := img.WriteAt(geom[:], base+bpbGeometryOffset); err != nil {
+			return fmt.Errorf("error writing disk geometry: %w", err)
+		}
+	}
+	return nil
+}
+
+// installSyslinux writes the SYSLINUX boot code into an image whose first
+// partition is a FAT32 filesystem already holding /ldlinux.sys. It must run
+// after the filesystem is closed and nothing else will move the file.
+func installSyslinux(path string, partStart int64, s *syslinuxFiles) (err error) {
+	img, err := os.OpenFile(path, os.O_RDWR, 0)
+	if err != nil {
+		return err
+	}
+	defer func() {
+		if cerr := img.Close(); err == nil {
+			err = cerr
+		}
+	}()
+
+	partOffset := partStart * BlockSize
+
+	// The MBR bootstrap. mbr.Table.Write only touches bytes 446 onwards, so
+	// writing here cannot disturb the partition table.
+	if _, err := img.WriteAt(s.mbr, 0); err != nil {
+		return fmt.Errorf("error writing MBR boot code: %w", err)
+	}
+
+	layout, err := readFATLayout(img, partOffset)
+	if err != nil {
+		return err
+	}
+
+	// go-diskfs will happily build a FAT32 with too few clusters to be one.
+	// SYSLINUX applies the standard rule and reads such a filesystem as
+	// FAT16, so the image gets as far as printing its banner and then
+	// cannot find ldlinux.c32. Catch it here rather than at boot.
+	if n := layout.clusterCount(); n <= fat32MinClusters {
+		return fmt.Errorf("partition has %d clusters, which reads as FAT16; "+
+			"FAT32 needs more than %d, so use --size 33 or larger", n, fat32MinClusters)
+	}
+
+	nsect := ldlinuxSectors(len(s.ldlinux))
+	sectors, err := ldlinuxSectorMap(img, partOffset, layout, nsect)
+	if err != nil {
+		return err
+	}
+
+	// Patch a private copy of the boot sector template, then merge it into
+	// the live boot sector: patchLdlinux writes the location of the first
+	// sector of ldlinux.sys into the template.
+	bootSect := make([]byte, BlockSize)
+	copy(bootSect, s.bootSect)
+
+	payload := ldlinuxPayload(s.ldlinux)
+	if err := patchLdlinux(payload, bootSect, len(s.ldlinux), sectors); err != nil {
+		return err
+	}
+
+	// Write the patched image back over the copy the filesystem holds.
+	for i, sector := range sectors {
+		off := partOffset + int64(sector)*BlockSize
+		if _, err := img.WriteAt(payload[i*BlockSize:(i+1)*BlockSize], off); err != nil {
+			return fmt.Errorf("error writing patched ldlinux.sys: %w", err)
+		}
+	}
+
+	// Merge the boot code into the partition's boot sector, keeping the BPB
+	// that describes the filesystem. The backup gets the same treatment so
+	// that it remains identical to the primary; the SYSLINUX installer
+	// leaves the backup stale, but there is no reason to copy that.
+	live := make([]byte, BlockSize)
+	if _, err := img.ReadAt(live, partOffset); err != nil {
+		return fmt.Errorf("error reading FAT boot sector: %w", err)
+	}
+	copy(live[bsHeadStart:bsHeadEnd], bootSect[bsHeadStart:bsHeadEnd])
+	copy(live[bsCodeStart:bsCodeEnd], bootSect[bsCodeStart:bsCodeEnd])
+
+	for _, sector := range []int64{0, fatBackupBootSector} {
+		if _, err := img.WriteAt(live, partOffset+sector*BlockSize); err != nil {
+			return fmt.Errorf("error writing FAT boot sector: %w", err)
+		}
+	}
+	return nil
+}

--- a/boot.go
+++ b/boot.go
@@ -2,14 +2,39 @@ package main
 
 // Legacy (BIOS) boot support, via SYSLINUX.
 //
+// Terminology, since this file is thick with it:
+//
+//   - LBA, Logical Block Address: a sector's number counting from the start
+//     of something, rather than the old cylinder/head/sector coordinates.
+//     "Absolute" LBAs count from the start of the disk; the sector numbers
+//     SYSLINUX works in count from the start of the partition, and the two
+//     differ by the partition's own starting LBA.
+//   - MBR, Master Boot Record: sector 0 of the disk. Holds up to 446 bytes
+//     of boot code, then the four-entry partition table, then 0x55AA.
+//   - VBR, Volume Boot Record, a.k.a. the boot sector: the first sector of a
+//     partition. On FAT it holds boot code wrapped around the BPB.
+//   - BPB, BIOS Parameter Block: the block of geometry fields inside the VBR
+//     that describes the filesystem -- sector size, cluster size, how many
+//     FATs, where the root directory starts, and so on. Bytes 11 to 89 of
+//     the sector on FAT32.
+//   - FAT, File Allocation Table: the array that chains clusters together.
+//     Entry N holds the number of the cluster that follows cluster N, or an
+//     end-of-chain marker. Walking it is how you find a file's data.
+//   - CHS, Cylinder/Head/Sector: the pre-LBA addressing scheme. Its geometry
+//     fields survive in the BPB and some boot code still falls back to them.
+//   - ADV, Auxiliary Data Vector: a 512-byte scratch area SYSLINUX keeps for
+//     itself at the end of ldlinux.sys, for things like "boot this once on
+//     the next reboot". Two copies, so an interrupted write cannot lose it.
+//     We write empty ones; nothing here uses the feature.
+//
 // Making a FAT32 image bootable by a PC BIOS takes four things beyond the
 // filesystem itself:
 //
 //  1. mbr.bin in the first 440 bytes of sector 0, to chainload the partition
 //     marked active;
-//  2. a BPB whose hidden-sector count is the partition's LBA — the SYSLINUX
-//     boot sector adds it to every filesystem-relative sector it reads, so a
-//     zero there sends it to the wrong end of the disk;
+//  2. a BPB whose hidden-sector count is the partition's starting LBA -- the
+//     SYSLINUX boot sector adds it to every partition-relative sector number
+//     it reads, so a zero there sends it to the wrong end of the disk;
 //  3. the SYSLINUX boot sector (ldlinux.bss) merged into the partition's
 //     first sector, leaving the BPB in place;
 //  4. ldlinux.sys on the filesystem, patched with the list of disk sectors it
@@ -38,37 +63,44 @@ const (
 	// are split so that no single one straddles a 64K boundary from here.
 	ldlinuxLoadAddr = 0x8000
 
-	// extentSize is sizeof(struct syslinux_extent): a 64-bit LBA and a
-	// 16-bit sector count, packed.
+	// extentSize is sizeof(struct syslinux_extent): a 64-bit starting LBA
+	// and a 16-bit count of how many sectors follow it, packed.
 	extentSize = 10
 
-	// advSize is the size of one Auxiliary Data Vector. Two of them are
-	// appended to ldlinux.sys on disk.
+	// advSize is the size of one ADV (Auxiliary Data Vector), SYSLINUX's
+	// own scratch area. Two of them are appended to ldlinux.sys on disk.
+	// The three magic numbers let SYSLINUX tell a good copy from a torn
+	// one: two signatures and a value the contents must sum to.
 	advSize   = 512
-	advMagic1 = 0x5a2d2fa5
-	advMagic2 = 0xa3041767
-	advMagic3 = 0xdd28bf64
+	advMagic1 = 0x5a2d2fa5 // head signature
+	advMagic2 = 0xa3041767 // what the body must sum to
+	advMagic3 = 0xdd28bf64 // tail signature
 
-	// ldlinuxName is the 8.3 short name of ldlinux.sys in the root
-	// directory, as it appears in the directory entry.
+	// ldlinuxName is the 8.3 short name of ldlinux.sys as it appears in the
+	// root directory: eight bytes of name and three of extension, space
+	// padded, with no dot between them.
 	ldlinuxName = "LDLINUX SYS"
 
-	// mbrBootstrapSize is the space before the disk signature and partition
-	// table in sector 0.
+	// mbrBootstrapSize is the space in the MBR before the disk signature
+	// and the partition table, which is all the boot code gets.
 	mbrBootstrapSize = 440
 
-	// bpbHiddenSectorsOffset is the offset of the 32-bit hidden-sector
-	// count within a FAT boot sector.
+	// bpbHiddenSectorsOffset is the offset within the boot sector of the
+	// BPB's 32-bit "hidden sectors" count -- the number of sectors before
+	// this partition, i.e. its own starting LBA.
 	bpbHiddenSectorsOffset = 0x1c
-	// bpbGeometryOffset is the offset of the 16-bit sectors-per-track
-	// field, immediately followed by the head count.
+	// bpbGeometryOffset is the offset of the BPB's 16-bit CHS
+	// sectors-per-track field, immediately followed by the head count.
 	bpbGeometryOffset = 0x18
-	// fatBackupBootSector is where go-diskfs mirrors the boot sector.
+	// fatBackupBootSector is the sector where FAT32 keeps a copy of the
+	// boot sector, and where go-diskfs writes one.
 	fatBackupBootSector = 6
 
-	// The two regions of a FAT32 boot sector that belong to SYSLINUX rather
-	// than to the filesystem: the jump and OEM name, and the boot code. The
-	// BPB between them, and the 0x55AA signature after it, are preserved.
+	// The two regions of a FAT32 boot sector (VBR) that belong to SYSLINUX
+	// rather than to the filesystem: the jump instruction and OEM name at
+	// the front, and the boot code after the BPB. The BPB between them
+	// (bytes 11 to 89) describes the filesystem and must survive, as must
+	// the 0x55AA signature in the last two bytes.
 	// From FAT_bsHead/FAT_bsCode in libinstaller/syslxint.h.
 	bsHeadStart, bsHeadEnd = 0, 11
 	bsCodeStart, bsCodeEnd = 90, 510
@@ -162,9 +194,14 @@ func ldlinuxPayload(ldlinux []byte) []byte {
 	return buf
 }
 
-// makeADV builds the pair of empty Auxiliary Data Vectors that SYSLINUX keeps
-// at the end of ldlinux.sys, following syslinux_reset_adv() and cleanup_adv()
-// in libinstaller/setadv.c. The two copies are identical.
+// makeADV builds the pair of empty ADVs (Auxiliary Data Vectors, SYSLINUX's
+// own scratch area) that live at the end of ldlinux.sys, following
+// syslinux_reset_adv() and cleanup_adv() in libinstaller/setadv.c.
+//
+// The layout is a head signature, a checksum chosen so the rest of the sector
+// sums to a second magic, the data, and a tail signature. Empty is all we
+// need: nothing fatimg does uses the features that store anything here. The
+// two copies are identical, which is what SYSLINUX expects to find.
 func makeADV() []byte {
 	adv := make([]byte, 2*advSize)
 	binary.LittleEndian.PutUint32(adv[0:4], advMagic1)
@@ -179,9 +216,11 @@ func makeADV() []byte {
 }
 
 // patchArea locates the patch area inside ldlinux.sys and reads the offsets
-// of the extended patch area out of it. All offsets are relative to the start
-// of the image except sect1ptr0 and sect1ptr1, which are offsets into the
-// boot sector.
+// of the extended patch area (EPA) out of it. The patch area is the struct
+// SYSLINUX leaves in its own image for an installer to fill in; the EPA is a
+// second struct it points at, holding the offsets of everything else that
+// needs writing. All offsets are relative to the start of the image except
+// sect1ptr0 and sect1ptr1, which are offsets into the boot sector.
 type patchArea struct {
 	offset int // of the patch area itself
 
@@ -315,10 +354,13 @@ func patchLdlinux(img, bootSect []byte, ldlinuxLen int, sectors []uint64) error 
 	return nil
 }
 
-// generateExtents packs a list of sectors into (lba, count) extents, merging
-// runs that are contiguous on disk. A run is broken when the corresponding
-// load address would cross a 64K boundary, since the boot sector reads through
-// a real-mode segmented address. Follows generate_extents() in syslxmod.c.
+// generateExtents packs a list of sector numbers into extents -- (starting
+// LBA, how many sectors follow) pairs -- merging runs that are contiguous on
+// disk, so that a file in one piece costs a couple of entries instead of one
+// per sector. A run is broken when it would reach 64K, the most a single BIOS
+// disk read can move, or when the address it loads to would cross a 64K
+// boundary in real-mode segmented memory. Follows generate_extents() in
+// syslxmod.c.
 func generateExtents(sectors []uint64, maxExtents int) ([]byte, error) {
 	out := make([]byte, 0, len(sectors)*extentSize)
 	addr := uint32(ldlinuxLoadAddr)
@@ -359,8 +401,13 @@ func generateExtents(sectors []uint64, maxExtents int) ([]byte, error) {
 	return out, nil
 }
 
-// fatLayout is the part of the FAT32 BPB needed to turn a cluster number into
-// a sector number relative to the start of the partition.
+// fatLayout is the part of the BPB needed to turn a cluster number into a
+// sector number relative to the start of the partition.
+//
+// A FAT32 volume is laid out as: reserved sectors (the boot sector and its
+// backup among them), then two copies of the FAT itself, then the data area
+// carved into fixed-size clusters. Cluster numbering starts at 2, which is
+// why converting one to a sector subtracts 2.
 type fatLayout struct {
 	sectorsPerCluster uint32
 	reservedSectors   uint32
@@ -411,8 +458,9 @@ func readFATLayout(img *os.File, partOffset int64) (fatLayout, error) {
 	return l, nil
 }
 
-// fatEOC is the first cluster value that terminates a chain; the top four bits
-// of a FAT32 entry are reserved.
+// fatEOC (end of chain) is the first FAT entry value that marks the last
+// cluster of a file rather than pointing at another one. Only the low 28 bits
+// of a FAT32 entry are the cluster number; the top four are reserved.
 const fatEOC = 0x0ffffff8
 
 // maxChainClusters bounds the walk so that a corrupt FAT cannot loop forever.
@@ -438,6 +486,11 @@ func (l fatLayout) chain(img *os.File, partOffset int64, start uint32) ([]uint32
 
 // findRootEntry returns the first cluster of a file in the root directory,
 // looked up by its 11-byte 8.3 short name.
+//
+// A directory is a list of 32-byte entries. Names too long or too mixed-case
+// for 8.3 get extra "long file name" entries in front of the real one, which
+// are skipped here: every file still has a short name, and that is what we
+// match on.
 func (l fatLayout) findRootEntry(img *os.File, partOffset int64, shortName string) (uint32, error) {
 	clusters, err := l.chain(img, partOffset, l.rootCluster)
 	if err != nil {
@@ -496,11 +549,16 @@ func ldlinuxSectorMap(img *os.File, partOffset int64, l fatLayout, n int) ([]uin
 	return sectors, nil
 }
 
-// fixBPBGeometry corrects the two BPB fields go-diskfs fills in with
-// placeholders: the hidden-sector count, which it always writes as zero, and
-// the CHS geometry, which it writes as 1/1 on the grounds that everything uses
-// LBA. Both are wrong for a filesystem inside a partition, and SYSLINUX needs
-// the first of them to find anything at all.
+// fixBPBGeometry corrects the two BPB (BIOS Parameter Block) fields go-diskfs
+// fills in with placeholders: the hidden-sector count, which it always writes
+// as zero, and the CHS geometry, which it writes as 1/1 on the grounds that
+// everything addresses by LBA these days.
+//
+// Both are wrong for a filesystem that lives inside a partition. Hidden
+// sectors is meant to say how many sectors precede the partition, and boot
+// code adds it to the partition-relative sector numbers it works in to get an
+// address it can hand to the BIOS -- so a zero there means every read lands
+// 1MB early, at the front of the disk.
 //
 // The backup boot sector is corrected too, so that it stays a copy.
 func fixBPBGeometry(img *os.File, partStart int64) error {

--- a/boot.go
+++ b/boot.go
@@ -1,3 +1,18 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (C) 2023-2026 Jason Sando
+//
+// The SYSLINUX installation in this file is derived from syslinux-6.03,
+// specifically syslinux_patch() and generate_extents() in
+// libinstaller/syslxmod.c and cleanup_adv() in libinstaller/setadv.c:
+//
+//	Copyright 1998-2008 H. Peter Anvin - All Rights Reserved
+//	Copyright 2009-2014 Intel Corporation; author H. Peter Anvin
+//
+// Those files are licensed under the GNU General Public License, version 2 or
+// (at your option) any later version. fatimg takes the later option and is
+// distributed under version 3; this is why the project is GPL rather than
+// permissively licensed.
+
 package main
 
 // Legacy (BIOS) boot support, via SYSLINUX.
@@ -144,8 +159,10 @@ func findSyslinuxFile(dir, name string) ([]byte, error) {
 }
 
 // loadSyslinuxFiles reads the SYSLINUX files out of dir, which should be a
-// syslinux release directory. The files are not embedded in fatimg because
-// SYSLINUX is GPL-2.0 and fatimg is Apache-2.0.
+// syslinux release directory. They are read at run time rather than embedded
+// so that fatimg ships as its own work: embedding them would put someone
+// else's binaries inside ours, with their own version skew and redistribution
+// obligations, for no gain over pointing at a release.
 func loadSyslinuxFiles(dir string) (*syslinuxFiles, error) {
 	s := &syslinuxFiles{}
 	for _, f := range []struct {

--- a/boot_test.go
+++ b/boot_test.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (C) 2023-2026 Jason Sando
+
 package main
 
 import (

--- a/boot_test.go
+++ b/boot_test.go
@@ -1,0 +1,315 @@
+package main
+
+import (
+	"encoding/binary"
+	"testing"
+)
+
+// Unit tests for the SYSLINUX patcher. These need no external tools: they
+// check the arithmetic that decides where the boot sector will look for
+// ldlinux.sys, which is the part with no visible failure mode short of
+// booting the image.
+
+// TestMakeADVIsConsistent checks the ADV against the rule adv_consistent()
+// applies in libinstaller/setadv.c: the two magic numbers must be in place and
+// the dwords from offset 4 to the tail must sum to ADV_MAGIC2.
+func TestMakeADVIsConsistent(t *testing.T) {
+	adv := makeADV()
+	if len(adv) != 2*advSize {
+		t.Fatalf("ADV is %d bytes, want %d", len(adv), 2*advSize)
+	}
+
+	for copyIndex := range 2 {
+		p := adv[copyIndex*advSize : (copyIndex+1)*advSize]
+
+		if got := binary.LittleEndian.Uint32(p[0:4]); got != advMagic1 {
+			t.Errorf("copy %d: head magic is %#x, want %#x", copyIndex, got, advMagic1)
+		}
+		if got := binary.LittleEndian.Uint32(p[advSize-4:]); got != advMagic3 {
+			t.Errorf("copy %d: tail magic is %#x, want %#x", copyIndex, got, advMagic3)
+		}
+
+		var csum uint32
+		for i := 4; i < advSize-4; i += 4 {
+			csum += binary.LittleEndian.Uint32(p[i : i+4])
+		}
+		if csum != advMagic2 {
+			t.Errorf("copy %d: checksum is %#x, want %#x", copyIndex, csum, advMagic2)
+		}
+	}
+}
+
+// TestLdlinuxSectors covers the sector count, which includes the two ADV
+// sectors and rounds a partial sector up.
+func TestLdlinuxSectors(t *testing.T) {
+	for _, tc := range []struct {
+		length int
+		want   int
+	}{
+		{1, 3},             // one byte still takes a whole sector
+		{BlockSize, 3},     // exactly one sector
+		{BlockSize + 1, 4}, // one byte into the second
+		{2 * BlockSize, 4}, //
+		{68599, 136},       // the ldlinux.sys shipped with syslinux 6.03
+	} {
+		if got := ldlinuxSectors(tc.length); got != tc.want {
+			t.Errorf("ldlinuxSectors(%d) = %d, want %d", tc.length, got, tc.want)
+		}
+	}
+}
+
+// decodeExtents unpacks the extent list back into (lba, len) pairs.
+func decodeExtents(t *testing.T, b []byte) [][2]uint64 {
+	t.Helper()
+	if len(b)%extentSize != 0 {
+		t.Fatalf("extent list is %d bytes, not a multiple of %d", len(b), extentSize)
+	}
+	var out [][2]uint64
+	for i := 0; i < len(b); i += extentSize {
+		out = append(out, [2]uint64{
+			binary.LittleEndian.Uint64(b[i : i+8]),
+			uint64(binary.LittleEndian.Uint16(b[i+8 : i+10])),
+		})
+	}
+	return out
+}
+
+func TestGenerateExtents(t *testing.T) {
+	// One extent has to stay under the 64K a single BIOS transfer can move,
+	// so a contiguous run is cut every 127 sectors however long it is.
+	const maxExtentSectors = 127
+
+	t.Run("a short contiguous run is one extent", func(t *testing.T) {
+		var sectors []uint64
+		for i := range uint64(100) {
+			sectors = append(sectors, 1000+i)
+		}
+		got := decodeExtents(t, mustExtents(t, sectors, 192))
+		assertExtents(t, got, [][2]uint64{{1000, 100}})
+	})
+
+	t.Run("a long contiguous run splits at the 64K transfer limit", func(t *testing.T) {
+		var sectors []uint64
+		for i := range uint64(200) {
+			sectors = append(sectors, 1000+i)
+		}
+		got := decodeExtents(t, mustExtents(t, sectors, 192))
+		assertExtents(t, got, [][2]uint64{
+			{1000, maxExtentSectors},
+			{1000 + maxExtentSectors, 200 - maxExtentSectors},
+		})
+	})
+
+	t.Run("a gap starts a new extent", func(t *testing.T) {
+		sectors := []uint64{10, 11, 12, 500, 501}
+		got := decodeExtents(t, mustExtents(t, sectors, 192))
+		assertExtents(t, got, [][2]uint64{{10, 3}, {500, 2}})
+	})
+
+	t.Run("fully fragmented", func(t *testing.T) {
+		sectors := []uint64{10, 20, 30}
+		got := decodeExtents(t, mustExtents(t, sectors, 192))
+		assertExtents(t, got, [][2]uint64{{10, 1}, {20, 1}, {30, 1}})
+	})
+
+	t.Run("empty", func(t *testing.T) {
+		if got := mustExtents(t, nil, 192); len(got) != 0 {
+			t.Errorf("expected no extents, got %d bytes", len(got))
+		}
+	})
+
+	// ldlinux.sys has room for a fixed number of extents. Overflowing it
+	// would silently truncate the sector map and produce an image that
+	// builds cleanly and does not boot.
+	t.Run("too fragmented to fit", func(t *testing.T) {
+		var sectors []uint64
+		for i := range uint64(10) {
+			sectors = append(sectors, i*2) // every one a separate extent
+		}
+		if _, err := generateExtents(sectors, 4); err == nil {
+			t.Fatal("expected an error when the extents do not fit, got nil")
+		}
+	})
+}
+
+func mustExtents(t *testing.T, sectors []uint64, max int) []byte {
+	t.Helper()
+	b, err := generateExtents(sectors, max)
+	if err != nil {
+		t.Fatalf("generateExtents: %v", err)
+	}
+	return b
+}
+
+func assertExtents(t *testing.T, got, want [][2]uint64) {
+	t.Helper()
+	if len(got) != len(want) {
+		t.Fatalf("got %d extents %v, want %d %v", len(got), got, len(want), want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Errorf("extent %d is (lba=%d, len=%d), want (lba=%d, len=%d)",
+				i, got[i][0], got[i][1], want[i][0], want[i][1])
+		}
+	}
+}
+
+// synthLdlinux builds a stand-in for ldlinux.sys with a patch area laid out
+// the way a real one is, so the patcher can be tested without shipping a
+// GPL binary in the repository.
+type synthOffsets struct {
+	patchArea, epa, secPtr, advPtr, dir int
+	secPtrCount, dirLen                 int
+	sect1Ptr0, sect1Ptr1                int
+}
+
+func synthLdlinux(t *testing.T) ([]byte, synthOffsets) {
+	t.Helper()
+	off := synthOffsets{
+		patchArea:   24,
+		secPtr:      512,
+		secPtrCount: 192,
+		epa:         5190,
+		advPtr:      5848,
+		dir:         5212,
+		dirLen:      256,
+		sect1Ptr0:   282,
+		sect1Ptr1:   288,
+	}
+	img := make([]byte, 8192)
+
+	// Fill with something non-zero so the checksum is not trivially right.
+	for i := range img {
+		img[i] = byte(i * 7)
+	}
+
+	binary.LittleEndian.PutUint32(img[off.patchArea:], ldlinuxMagic)
+	binary.LittleEndian.PutUint16(img[off.patchArea+22:], uint16(off.epa))
+
+	binary.LittleEndian.PutUint16(img[off.epa+0:], uint16(off.advPtr))
+	binary.LittleEndian.PutUint16(img[off.epa+2:], uint16(off.dir))
+	binary.LittleEndian.PutUint16(img[off.epa+4:], uint16(off.dirLen))
+	binary.LittleEndian.PutUint16(img[off.epa+10:], uint16(off.secPtr))
+	binary.LittleEndian.PutUint16(img[off.epa+12:], uint16(off.secPtrCount))
+	binary.LittleEndian.PutUint16(img[off.epa+14:], uint16(off.sect1Ptr0))
+	binary.LittleEndian.PutUint16(img[off.epa+16:], uint16(off.sect1Ptr1))
+	return img, off
+}
+
+func TestFindPatchArea(t *testing.T) {
+	img, off := synthLdlinux(t)
+	pa, err := findPatchArea(img)
+	if err != nil {
+		t.Fatalf("findPatchArea: %v", err)
+	}
+	for _, c := range []struct {
+		name      string
+		got, want int
+	}{
+		{"offset", pa.offset, off.patchArea},
+		{"epa", pa.epa, off.epa},
+		{"advPtrOffset", pa.advPtrOffset, off.advPtr},
+		{"dirOffset", pa.dirOffset, off.dir},
+		{"dirLen", pa.dirLen, off.dirLen},
+		{"secPtrOffset", pa.secPtrOffset, off.secPtr},
+		{"secPtrCount", pa.secPtrCount, off.secPtrCount},
+		{"sect1Ptr0", pa.sect1Ptr0, off.sect1Ptr0},
+		{"sect1Ptr1", pa.sect1Ptr1, off.sect1Ptr1},
+	} {
+		if c.got != c.want {
+			t.Errorf("%s = %d, want %d", c.name, c.got, c.want)
+		}
+	}
+
+	t.Run("no magic", func(t *testing.T) {
+		if _, err := findPatchArea(make([]byte, 4096)); err == nil {
+			t.Fatal("expected an error for an image with no patch area")
+		}
+	})
+}
+
+// TestPatchLdlinux checks the two things ldlinux.sys verifies about itself at
+// boot: that the boot sector was told where its first sector is, and that its
+// dwords sum to the magic. A wrong checksum stops the boot dead, and there is
+// no way to notice before then.
+func TestPatchLdlinux(t *testing.T) {
+	img, off := synthLdlinux(t)
+	ldlinuxLen := len(img) - 2*advSize
+	padded := make([]byte, len(img))
+	copy(padded, img)
+
+	nsect := ldlinuxSectors(ldlinuxLen)
+	sectors := make([]uint64, nsect)
+	for i := range sectors {
+		sectors[i] = uint64(1000 + i)
+	}
+
+	bootSect := make([]byte, BlockSize)
+	if err := patchLdlinux(padded, bootSect, ldlinuxLen, sectors); err != nil {
+		t.Fatalf("patchLdlinux: %v", err)
+	}
+
+	// The boot sector loads the first sector itself.
+	if got := binary.LittleEndian.Uint32(bootSect[off.sect1Ptr0:]); got != uint32(sectors[0]) {
+		t.Errorf("boot sector holds first sector %d, want %d", got, sectors[0])
+	}
+	if got := binary.LittleEndian.Uint32(bootSect[off.sect1Ptr1:]); got != 0 {
+		t.Errorf("high half of the first sector pointer is %d, want 0", got)
+	}
+
+	// The last two sectors are the ADVs.
+	if got := binary.LittleEndian.Uint64(padded[off.advPtr:]); got != sectors[nsect-2] {
+		t.Errorf("first ADV pointer is %d, want %d", got, sectors[nsect-2])
+	}
+	if got := binary.LittleEndian.Uint64(padded[off.advPtr+8:]); got != sectors[nsect-1] {
+		t.Errorf("second ADV pointer is %d, want %d", got, sectors[nsect-1])
+	}
+
+	// Totals, excluding the ADVs.
+	if got := binary.LittleEndian.Uint16(padded[off.patchArea+8:]); int(got) != nsect-2 {
+		t.Errorf("data_sectors is %d, want %d", got, nsect-2)
+	}
+	if got := binary.LittleEndian.Uint16(padded[off.patchArea+10:]); got != 2 {
+		t.Errorf("adv_sectors is %d, want 2", got)
+	}
+
+	// The self-check ldlinux.sys runs: summing its dwords yields the magic.
+	var csum uint32
+	for i := range ldlinuxLen >> 2 {
+		csum += binary.LittleEndian.Uint32(padded[i*4 : i*4+4])
+	}
+	if csum != ldlinuxMagic {
+		t.Errorf("dwords sum to %#x, want %#x", csum, uint32(ldlinuxMagic))
+	}
+
+	t.Run("too few sectors", func(t *testing.T) {
+		img, _ := synthLdlinux(t)
+		if err := patchLdlinux(img, make([]byte, BlockSize), ldlinuxLen, sectors[:2]); err == nil {
+			t.Fatal("expected an error when the file is shorter than its image")
+		}
+	})
+}
+
+// TestClusterCount checks the FAT16/FAT32 boundary arithmetic, which is what
+// makes a too-small partition unbootable.
+func TestClusterCount(t *testing.T) {
+	l := fatLayout{
+		sectorsPerCluster: 1,
+		reservedSectors:   32,
+		fatCount:          2,
+		sectorsPerFat:     511,
+		totalSectors:      65536,
+	}
+	// A 32MB partition: the size that reads as FAT16 despite the BPB.
+	if got := l.clusterCount(); got != 64482 {
+		t.Errorf("clusterCount() = %d, want 64482", got)
+	}
+	if l.clusterCount() > fat32MinClusters {
+		t.Error("a 32MB partition should not qualify as FAT32")
+	}
+
+	l.totalSectors = 2 * 65536 // 64MB
+	if l.clusterCount() <= fat32MinClusters {
+		t.Error("a 64MB partition should qualify as FAT32")
+	}
+}

--- a/copy.go
+++ b/copy.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (C) 2023-2026 Jason Sando
+
 package main
 
 import (

--- a/create.go
+++ b/create.go
@@ -23,7 +23,7 @@ type CreateCommand struct {
 	outputPath      string
 	partitionMB     int
 	trimImage       bool
-	biosBoot        bool
+	syslinuxBoot    bool
 	syslinuxDir     string
 	partType        string
 	syslinux        *syslinuxFiles
@@ -59,8 +59,8 @@ func NewCreateCommand() *CreateCommand {
 	cmd.fs.IntVar(&cmd.partitionMB, "size", 1024, "partition size in megabytes")
 	cmd.fs.BoolVar(&cmd.gzipOutput, "gzip", false, "compress output file with gzip (automatic if output ends with '.gz')")
 	cmd.fs.BoolVar(&cmd.trimImage, "trim", false, "trim disk image before compressing (truncate zero-filled sectors at the end)")
-	cmd.fs.BoolVar(&cmd.biosBoot, "bios-boot", false, "make the image bootable by a legacy BIOS, using SYSLINUX")
-	cmd.fs.StringVar(&cmd.syslinuxDir, "syslinux-dir", "", "directory holding the SYSLINUX release to install (required with --bios-boot)")
+	cmd.fs.BoolVar(&cmd.syslinuxBoot, "syslinux", false, "make the image bootable by a legacy BIOS, using SYSLINUX")
+	cmd.fs.StringVar(&cmd.syslinuxDir, "syslinux-dir", "", "directory holding the SYSLINUX release to install (required with --syslinux)")
 	cmd.fs.StringVar(&cmd.partType, "part-type", partTypeEFI, fmt.Sprintf("MBR partition type, %q or %q", partTypeEFI, partTypeFAT32))
 	cmd.fs.Usage = func() {
 		fmt.Fprintf(os.Stderr, `Create a disk image with a FAT32 partition.
@@ -69,7 +69,7 @@ The contents of the partition are specified as a list of one or more paths.
 Folders are copied recursively, and include the folder name itself
 unless it ends with a trailing '/'.
 
-With --bios-boot the image is also made bootable by a legacy BIOS. This
+With --syslinux the image is also made bootable by a legacy BIOS. This
 installs SYSLINUX, whose files are read from --syslinux-dir; they are not
 bundled with fatimg because SYSLINUX is licensed under the GPL. Point it at
 an unpacked syslinux release tarball, which ships the mbr.bin, ldlinux.bss,
@@ -87,7 +87,7 @@ Options:
 Examples:
   fatimg create --output disk.img ./boot/
   fatimg create --output boot.img.gz --size 512 --label BOOT ./EFI/
-  fatimg create --output disk.img --bios-boot --syslinux-dir ~/syslinux-6.03 \
+  fatimg create --output disk.img --syslinux --syslinux-dir ~/syslinux-6.03 \
       --part-type fat32 ./boot/
 `)
 	}
@@ -131,11 +131,11 @@ func (c *CreateCommand) Run(args []string) error {
 
 	// SYSLINUX is GPL-licensed, so its files are not bundled; the user has
 	// to point at a copy.
-	if c.biosBoot && c.syslinuxDir == "" {
+	if c.syslinuxBoot && c.syslinuxDir == "" {
 		c.fs.Usage()
-		return fmt.Errorf("--bios-boot requires --syslinux-dir")
+		return fmt.Errorf("--syslinux requires --syslinux-dir")
 	}
-	if c.biosBoot {
+	if c.syslinuxBoot {
 		c.syslinux, err = loadSyslinuxFiles(c.syslinuxDir)
 		if err != nil {
 			return err
@@ -324,7 +324,7 @@ func (c *CreateCommand) createDiskImage(tempFileName string) error {
 	// lands at the front of the data area in one piece. It is addressed by
 	// a sector map with limited room for extents, so fragmenting it behind
 	// a few hundred megabytes of payload is a real failure mode.
-	if c.biosBoot {
+	if c.syslinuxBoot {
 		if err = writeFileBytes(fs, "/ldlinux.sys", ldlinuxPayload(c.syslinux.ldlinux)); err != nil {
 			return err
 		}
@@ -378,7 +378,7 @@ func (c *CreateCommand) createDiskImage(tempFileName string) error {
 		return err
 	}
 
-	if c.biosBoot {
+	if c.syslinuxBoot {
 		if err = installSyslinux(tempFileName, PartitionStart, c.syslinux); err != nil {
 			return fmt.Errorf("error installing SYSLINUX: %w", err)
 		}

--- a/create.go
+++ b/create.go
@@ -23,7 +23,30 @@ type CreateCommand struct {
 	outputPath      string
 	partitionMB     int
 	trimImage       bool
+	biosBoot        bool
+	syslinuxDir     string
+	partType        string
+	syslinux        *syslinuxFiles
 	includes        []string
+}
+
+// Partition type names accepted by --part-type. EFI is the historical default;
+// a BIOS-only image is more conventionally 0x0c, and some firmware refuses to
+// boot an EFI system partition.
+const (
+	partTypeEFI   = "efi"
+	partTypeFAT32 = "fat32"
+)
+
+func mbrPartitionType(name string) (mbr.Type, error) {
+	switch name {
+	case partTypeEFI:
+		return mbr.EFISystem, nil
+	case partTypeFAT32:
+		return mbr.Fat32LBA, nil
+	default:
+		return 0, fmt.Errorf("unknown partition type %q, expected %q or %q", name, partTypeEFI, partTypeFAT32)
+	}
 }
 
 func NewCreateCommand() *CreateCommand {
@@ -36,12 +59,23 @@ func NewCreateCommand() *CreateCommand {
 	cmd.fs.IntVar(&cmd.partitionMB, "size", 1024, "partition size in megabytes")
 	cmd.fs.BoolVar(&cmd.gzipOutput, "gzip", false, "compress output file with gzip (automatic if output ends with '.gz')")
 	cmd.fs.BoolVar(&cmd.trimImage, "trim", false, "trim disk image before compressing (truncate zero-filled sectors at the end)")
+	cmd.fs.BoolVar(&cmd.biosBoot, "bios-boot", false, "make the image bootable by a legacy BIOS, using SYSLINUX")
+	cmd.fs.StringVar(&cmd.syslinuxDir, "syslinux-dir", "", "directory holding the SYSLINUX release to install (required with --bios-boot)")
+	cmd.fs.StringVar(&cmd.partType, "part-type", partTypeEFI, fmt.Sprintf("MBR partition type, %q or %q", partTypeEFI, partTypeFAT32))
 	cmd.fs.Usage = func() {
-		fmt.Fprintf(os.Stderr, `Create a disk image with an EFI partition.
+		fmt.Fprintf(os.Stderr, `Create a disk image with a FAT32 partition.
 
 The contents of the partition are specified as a list of one or more paths.
 Folders are copied recursively, and include the folder name itself
 unless it ends with a trailing '/'.
+
+With --bios-boot the image is also made bootable by a legacy BIOS. This
+installs SYSLINUX, whose files are read from --syslinux-dir; they are not
+bundled with fatimg because SYSLINUX is licensed under the GPL. Point it at
+an unpacked syslinux release tarball, which ships the mbr.bin, ldlinux.bss,
+ldlinux.sys and ldlinux.c32 an install needs; most distribution packages do
+not, because their installer has them built in. You supply the syslinux.cfg
+yourself, as one of the paths to copy in.
 
 Usage:
   fatimg create [options] <path> [<path> ...]
@@ -53,6 +87,8 @@ Options:
 Examples:
   fatimg create --output disk.img ./boot/
   fatimg create --output boot.img.gz --size 512 --label BOOT ./EFI/
+  fatimg create --output disk.img --bios-boot --syslinux-dir ~/syslinux-6.03 \
+      --part-type fat32 ./boot/
 `)
 	}
 	return cmd
@@ -87,6 +123,24 @@ func (c *CreateCommand) Run(args []string) error {
 		return fmt.Errorf("at least one valid path is required")
 	}
 	c.includes = c.fs.Args()
+
+	if _, err := mbrPartitionType(c.partType); err != nil {
+		c.fs.Usage()
+		return err
+	}
+
+	// SYSLINUX is GPL-licensed, so its files are not bundled; the user has
+	// to point at a copy.
+	if c.biosBoot && c.syslinuxDir == "" {
+		c.fs.Usage()
+		return fmt.Errorf("--bios-boot requires --syslinux-dir")
+	}
+	if c.biosBoot {
+		c.syslinux, err = loadSyslinuxFiles(c.syslinuxDir)
+		if err != nil {
+			return err
+		}
+	}
 
 	// if outputPath ends with ".gz" then automatically turn on the doGzip flag
 	if strings.HasSuffix(c.outputPath, ".gz") {
@@ -239,13 +293,18 @@ func (c *CreateCommand) createDiskImage(tempFileName string) error {
 		return err
 	}
 
+	partType, err := mbrPartitionType(c.partType)
+	if err != nil {
+		return err
+	}
+
 	// create a partition table
 	table := &mbr.Table{
 		Partitions: []*mbr.Partition{
 			{
 				Start:    PartitionStart,
 				Size:     uint32(partitionSectors), // Note: limits partition to ~2TB
-				Type:     mbr.EFISystem,
+				Type:     partType,
 				Bootable: true,
 			},
 		},
@@ -259,6 +318,19 @@ func (c *CreateCommand) createDiskImage(tempFileName string) error {
 	fs, err := myDisk.CreateFilesystem(spec)
 	if err != nil {
 		return err
+	}
+
+	// Write the SYSLINUX files before anything else, so that ldlinux.sys
+	// lands at the front of the data area in one piece. It is addressed by
+	// a sector map with limited room for extents, so fragmenting it behind
+	// a few hundred megabytes of payload is a real failure mode.
+	if c.biosBoot {
+		if err = writeFileBytes(fs, "/ldlinux.sys", ldlinuxPayload(c.syslinux.ldlinux)); err != nil {
+			return err
+		}
+		if err = writeFileBytes(fs, "/ldlinux.c32", c.syslinux.c32); err != nil {
+			return err
+		}
 	}
 
 	for _, include := range c.includes {
@@ -287,8 +359,49 @@ func (c *CreateCommand) createDiskImage(tempFileName string) error {
 			}
 		}
 	}
-	err = myDisk.Close()
-	return err
+	if err = myDisk.Close(); err != nil {
+		return err
+	}
+
+	// From here the image is just a file. go-diskfs leaves placeholders in
+	// two BPB fields that are wrong for a filesystem inside a partition, so
+	// correct them whether or not this image is going to be bootable.
+	img, err := os.OpenFile(tempFileName, os.O_RDWR, 0)
+	if err != nil {
+		return err
+	}
+	err = fixBPBGeometry(img, PartitionStart)
+	if cerr := img.Close(); err == nil {
+		err = cerr
+	}
+	if err != nil {
+		return err
+	}
+
+	if c.biosBoot {
+		if err = installSyslinux(tempFileName, PartitionStart, c.syslinux); err != nil {
+			return fmt.Errorf("error installing SYSLINUX: %w", err)
+		}
+	}
+	return nil
+}
+
+// writeFileBytes writes an in-memory blob to a file in the image. Like
+// copyFile it writes in a single call so that FAT32 allocates the cluster
+// chain once.
+func writeFileBytes(fs filesystem.FileSystem, dst string, data []byte) error {
+	rw, err := fs.OpenFile(dst, os.O_CREATE|os.O_RDWR)
+	if err != nil {
+		return fmt.Errorf("error writing output file '%s': %s", dst, err.Error())
+	}
+	n, err := rw.Write(data)
+	if err != nil {
+		return err
+	}
+	if n != len(data) {
+		return fmt.Errorf("error writing output file '%s': %d bytes written, s/b %d", dst, n, len(data))
+	}
+	return rw.Close()
 }
 
 // reRootPath maps a source path to its destination inside the image by

--- a/create.go
+++ b/create.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (C) 2023-2026 Jason Sando
+
 package main
 
 import (

--- a/create_test.go
+++ b/create_test.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (C) 2023-2026 Jason Sando
+
 package main
 
 import (

--- a/external_test.go
+++ b/external_test.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (C) 2023-2026 Jason Sando
+
 package main
 
 import (

--- a/list.go
+++ b/list.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (C) 2023-2026 Jason Sando
+
 package main
 
 import (

--- a/main.go
+++ b/main.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (C) 2023-2026 Jason Sando
+
 package main
 
 import (

--- a/qemu_test.go
+++ b/qemu_test.go
@@ -1,0 +1,180 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+// The fourth validation tier: boot the image on an emulated PC.
+//
+// Nothing below this tier can catch a broken bootloader install. An image with
+// no boot code in it at all passes every round-trip test in this suite and is
+// pronounced healthy by fsck.fat, because a boot sector is not part of the
+// filesystem as far as a filesystem checker is concerned. The only way to know
+// that the sector map stamped into ldlinux.sys points where the boot sector
+// will look is to let a BIOS follow it.
+
+// bootMarker is the label named by DEFAULT in the test's syslinux.cfg. It is
+// not a real kernel, so SYSLINUX prints it and fails to load it -- which is
+// all we need, since reaching that point means the whole chain worked.
+const bootMarker = "fatimg-boot-marker"
+
+// bootConfig is the syslinux.cfg written into the test image. SERIAL redirects
+// SYSLINUX to the serial port, which is how the test observes it; CONSOLE 0
+// stops it also writing to a VGA console nobody is reading.
+const bootConfig = `SERIAL 0 115200
+CONSOLE 0
+PROMPT 0
+TIMEOUT 50
+DEFAULT ` + bootMarker + `
+`
+
+// syslinuxDir returns the SYSLINUX release to install from. Like the mtools
+// and dosfstools requirements, a missing one fails rather than skips: a
+// validation tier that quietly does not run looks exactly like a passing one.
+func syslinuxDir(t *testing.T) string {
+	t.Helper()
+	dir := os.Getenv("FATIMG_SYSLINUX_DIR")
+	if dir == "" {
+		t.Fatal("FATIMG_SYSLINUX_DIR is not set.\n" +
+			"The boot test installs SYSLINUX from an unpacked release, which is not\n" +
+			"bundled with fatimg because it is GPL-licensed. Run `make boot`, which\n" +
+			"downloads one and sets this for you, or point it at your own copy.")
+	}
+	if _, err := os.Stat(dir); err != nil {
+		t.Fatalf("FATIMG_SYSLINUX_DIR is set to %s, which is not readable: %v", dir, err)
+	}
+	return dir
+}
+
+func qemuBinary(t *testing.T) string {
+	t.Helper()
+	bin, err := exec.LookPath("qemu-system-x86_64")
+	if err != nil {
+		t.Fatal("qemu-system-x86_64 not found on PATH.\n" +
+			"The boot test runs the image on an emulated PC; install QEMU:\n" +
+			"  macOS:  brew install qemu\n" +
+			"  Debian: sudo apt-get install qemu-system-x86\n" +
+			"Or run `make unit` for the tests that do not need it.")
+	}
+	return bin
+}
+
+// TestBIOSBootInQEMU builds a bootable image and checks that SYSLINUX got far
+// enough to read the syslinux.cfg we put in it. That covers the whole chain:
+// the MBR bootstrap, the patched FAT boot sector, ldlinux.sys located through
+// its sector map and passing its own checksum, and ldlinux.c32 found on the
+// filesystem.
+func TestBIOSBootInQEMU(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping boot test in short mode")
+	}
+	qemu := qemuBinary(t)
+	syslinux := syslinuxDir(t)
+
+	// Both partition types should boot: a BIOS goes by the active flag, not
+	// the type byte. fat32 is the more conventional choice for a BIOS-only
+	// image, efi is what fatimg has always written.
+	for _, partType := range []string{partTypeFAT32, partTypeEFI} {
+		t.Run(partType, func(t *testing.T) {
+			dir := t.TempDir()
+
+			src := filepath.Join(dir, "src")
+			if err := os.MkdirAll(src, 0o755); err != nil {
+				t.Fatalf("creating source tree: %v", err)
+			}
+			if err := os.WriteFile(filepath.Join(src, "syslinux.cfg"), []byte(bootConfig), 0o644); err != nil {
+				t.Fatalf("writing syslinux.cfg: %v", err)
+			}
+
+			// The trailing slash copies the contents rather than the
+			// directory, putting syslinux.cfg in the root where
+			// SYSLINUX looks for it.
+			image := filepath.Join(dir, "boot.img")
+			if err := runCmd(t, "create", "--output", image, "--size", "64",
+				"--bios-boot", "--syslinux-dir", syslinux,
+				"--part-type", partType, src+"/"); err != nil {
+				t.Fatalf("create: %v", err)
+			}
+
+			out := bootImage(t, qemu, image, 90*time.Second)
+			if !strings.Contains(out, "SYSLINUX") {
+				t.Errorf("SYSLINUX never reached the serial console.\nSerial output:\n%s", out)
+			}
+			if !strings.Contains(out, bootMarker) {
+				t.Errorf("SYSLINUX did not read our syslinux.cfg (no %q in output).\nSerial output:\n%s",
+					bootMarker, out)
+			}
+		})
+	}
+}
+
+// bootImage runs the image under QEMU until the marker appears on the serial
+// port or the deadline passes, and returns whatever the serial port produced.
+func bootImage(t *testing.T, qemu, image string, timeout time.Duration) string {
+	t.Helper()
+
+	serial := filepath.Join(t.TempDir(), "serial.txt")
+
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+
+	var stderr bytes.Buffer
+	cmd := exec.CommandContext(ctx, qemu,
+		"-display", "none", // no window; this runs in CI
+		"-no-reboot", // stop rather than loop on boot failure
+		"-m", "256",
+		"-drive", "file="+image+",format=raw,if=ide",
+		"-serial", "file:"+serial,
+	)
+	cmd.Stderr = &stderr
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("starting qemu: %v", err)
+	}
+
+	exited := make(chan error, 1)
+	go func() { exited <- cmd.Wait() }()
+	defer func() {
+		cancel()
+		<-exited
+	}()
+
+	readSerial := func() string {
+		b, err := os.ReadFile(serial)
+		if err != nil && !os.IsNotExist(err) {
+			t.Fatalf("reading serial log: %v", err)
+		}
+		return string(b)
+	}
+
+	// QEMU has no reason to exit on its own -- SYSLINUX sits at its boot
+	// prompt -- so poll the serial log and stop as soon as it says what we
+	// are waiting for. If QEMU exits first it failed to start, and its
+	// stderr says why; without this the test would just wait out the
+	// timeout and report an empty serial log.
+	tick := time.NewTicker(100 * time.Millisecond)
+	defer tick.Stop()
+	for {
+		select {
+		case err := <-exited:
+			exited <- err
+			if out := readSerial(); strings.Contains(out, bootMarker) {
+				return out
+			}
+			t.Fatalf("qemu exited before the image booted: %v\nqemu stderr:\n%s\nserial output:\n%s",
+				err, stderr.String(), readSerial())
+		case <-ctx.Done():
+			return readSerial()
+		case <-tick.C:
+			if out := readSerial(); strings.Contains(out, bootMarker) {
+				return out
+			}
+		}
+	}
+}

--- a/qemu_test.go
+++ b/qemu_test.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (C) 2023-2026 Jason Sando
+
 package main
 
 import (

--- a/qemu_test.go
+++ b/qemu_test.go
@@ -98,7 +98,7 @@ func TestBIOSBootInQEMU(t *testing.T) {
 			// SYSLINUX looks for it.
 			image := filepath.Join(dir, "boot.img")
 			if err := runCmd(t, "create", "--output", image, "--size", "64",
-				"--bios-boot", "--syslinux-dir", syslinux,
+				"--syslinux", "--syslinux-dir", syslinux,
 				"--part-type", partType, src+"/"); err != nil {
 				t.Fatalf("create: %v", err)
 			}

--- a/roundtrip_test.go
+++ b/roundtrip_test.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (C) 2023-2026 Jason Sando
+
 package main
 
 import (


### PR DESCRIPTION
Adds legacy BIOS boot to `create`, via SYSLINUX, behind a new `--syslinux` flag. Images built without it are unchanged apart from one BPB repair described below.

## Read this part first: the project relicenses to GPLv3

`boot.go` is derived from syslinux-6.03 — `syslinux_patch()` and `generate_extents()` in `libinstaller/syslxmod.c`, and `cleanup_adv()` in `libinstaller/setadv.c`, copyright 1998-2008 H. Peter Anvin and 2009-2014 Intel Corporation. Those are GPL-2.0-or-later. fatimg takes the "or later" option, so **the whole project moves from Apache-2.0 to GPL-3.0-or-later.**

This is the real decision in this PR, and it is not reversible for anyone who takes a dependency on a GPL release. Merging it means:

- Every source file gains an SPDX header; `LICENSE` is replaced.
- The Homebrew formula's `license:` changes. (Note it currently says `MIT`, which was already wrong — `main` is Apache-2.0. See "unrelated bug" below.)
- Releases up to the last Apache-2.0 tag stay available under those terms; this only affects what comes after.

If that trade isn't worth legacy BIOS boot, the alternative is to close this and cherry-pick just the BPB fix — I have that as a local draft.

SYSLINUX itself is neither vendored nor embedded. Its files are read from `--syslinux-dir` at run time, so we don't redistribute anyone else's binaries.

## What changes for existing users

Only one thing, and it applies to **every** image, `--syslinux` or not:

**`fixBPBGeometry` repairs two BIOS Parameter Block fields** that go-diskfs writes as though the filesystem owned the whole disk:

- hidden sectors: `0` → the partition's actual starting LBA
- CHS geometry: 1 sector/track, 1 head → the conventional 63/255

...in both the primary boot sector and the FAT32 backup at sector 6. Neither matters to code reading by absolute LBA, which is why current images work at all. They matter to anything trusting the BPB — mtools already rejects our geometry with "Bad configuration" (see the comment at `external_test.go:48`), and boot code adds hidden sectors to every sector number it reads.

So this is a conformance fix that stands on its own merits, independent of BIOS boot.

Everything else is gated behind `--syslinux` or is cosmetic:

| Change | Effect without `--syslinux` |
|---|---|
| `--part-type efi\|fat32` | New flag, defaults to `efi` — no behaviour change |
| `ldlinux.sys`/`.c32` written first, `installSyslinux`, FAT16-cluster rejection | None, all behind `if c.syslinuxBoot` |
| Usage text "an EFI partition" → "a FAT32 partition" | Cosmetic |

## How the install works

Four things make a FAT32 image BIOS-bootable, and only the last is real work: `mbr.bin` in the first 440 bytes of sector 0; a correct hidden-sector count; the SYSLINUX boot sector merged into the partition, keeping the BPB; and `ldlinux.sys` patched with the list of disk sectors it occupies. A 512-byte boot sector can't walk a FAT chain, so the sector map is stamped in at install time along with a checksum ldlinux.sys verifies against itself at boot.

Two details worth knowing when reviewing:

- **Structure offsets are read out of the image, not hardcoded.** They're a property of the ldlinux.sys build being installed, which is also why the files must all come from one release.
- **ldlinux.sys is written before the user's files** so it lands contiguously. It's addressed by an extent list with room for 192 entries; `generateExtents` errors rather than truncating if a fragmented file would overflow it.
- **A FAT32 with ≤65524 clusters reads as FAT16** by the standard rule, and SYSLINUX applies it. `installSyslinux` rejects such an image up front — without that check the symptom is a boot that prints the SYSLINUX banner and then can't find `ldlinux.c32`, a long way from the cause.

`boot.go` and the CLAUDE.md section carry the full detail.

## Testing

Adds a fourth tier below the existing three, because nothing below it can catch a broken bootloader install — an image with *no boot code at all* passes every other test here, since a boot sector isn't part of the filesystem as far as `fsck.fat` is concerned.

- **Unit** (`boot_test.go`, 6 tests): the patch arithmetic — `TestGenerateExtents`, `TestPatchLdlinux`, `TestFindPatchArea`, `TestLdlinuxSectors`, `TestMakeADVIsConsistent`, `TestClusterCount`.
- **Boot** (`qemu_test.go`): `TestBIOSBootInQEMU` builds a `--syslinux` image, runs it on an emulated PC, and checks SYSLINUX reached the `syslinux.cfg` in the image. Covers both `fat32` and `efi` partition types.

CI installs `qemu-system-x86` and fetches the SYSLINUX release; `make syslinux` does the same locally and `make boot` runs just that tier. `make check` passes.

## Unrelated bug this happens to fix

`.goreleaser.yaml` declares `license: "MIT"` while `main` is Apache-2.0 — so the published Homebrew formula has been advertising the wrong license. This PR corrects it to `GPL-3.0-or-later` as part of the relicense. If this PR is closed, that line still needs a one-line fix on `main`.

## One fix found by CI on this PR

`release.yml` has its own test job, because tag pushes don't trigger `ci.yml` and that job is what stands between a bad tag and a published release. It installed only mtools and dosfstools and called `go test` directly — so once the boot test existed, that job failed outright: no qemu on PATH, and no `FATIMG_SYSLINUX_DIR`, which the Makefile exports. Fixed in 82ff38e by mirroring `ci.yml`.

Worth noting *how* that surfaced: the boot test hard-fails rather than skipping when qemu is missing. Had it skipped, the release gate would have quietly stopped covering the one tier that can catch a broken bootloader install, and nothing would have gone red.
